### PR TITLE
lambda関数のコード量削減

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -30,6 +30,10 @@ export class CdkStack extends cdk.Stack {
         functionName: `youtube_streaming_watcher_${functionName}_function`,
         entry: `src/${functionName}/index.ts`,
         runtime: lambda.Runtime.NODEJS_14_X,
+        bundling: {
+          minify: true,
+          sourceMap: true
+        },
         environment: {
           SLACK_BOT_TOKEN: slackSecret.secretValueFromJson('slack_bot_token').toString(),
           SLACK_CHANNEL: slackSecret.secretValueFromJson('slack_channel').toString(),

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -30,10 +30,7 @@ export class CdkStack extends cdk.Stack {
         functionName: `youtube_streaming_watcher_${functionName}_function`,
         entry: `src/${functionName}/index.ts`,
         runtime: lambda.Runtime.NODEJS_14_X,
-        bundling: {
-          minify: true,
-          sourceMap: true
-        },
+        bundling: { minify: true },
         environment: {
           SLACK_BOT_TOKEN: slackSecret.secretValueFromJson('slack_bot_token').toString(),
           SLACK_CHANNEL: slackSecret.secretValueFromJson('slack_channel').toString(),


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/pull/44#issuecomment-1037063069

```
Bundling asset Stack-youtube-streaming-watcher/Function-notify/Code/Stage...
esbuild cannot run locally. Switching to Docker bundling.

  asset-output/index.js  19.0mb ⚠️
...
Bundling asset Stack-youtube-streaming-watcher/Function-reply/Code/Stage...
esbuild cannot run locally. Switching to Docker bundling.

  asset-output/index.js  3.3mb ⚠️
```

lambda関数のコード量が多いので、minifyを有効にします。