### PR TITLE
super-linterでslimイメージを使用する

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -55,7 +55,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4.8.7
+        uses: github/super-linter/slim@v4.8.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: .idea/.*

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -60,3 +60,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: .idea/.*
           PATH: /github/workspace/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node_modules/.bin:/venvs/ansible-lint/bin:/venvs/black/bin:/venvs/cfn-lint/bin:/venvs/cpplint/bin:/venvs/flake8/bin:/venvs/isort/bin:/venvs/mypy/bin:/venvs/pylint/bin:/venvs/snakefmt/bin:/venvs/snakemake/bin:/venvs/sqlfluff/bin:/venvs/yamllint/bin:/venvs/yq/bin:/var/cache/dotnet/tools:/usr/share/dotnet
+      - name: Lint dotenv
+        uses: dotenv-linter/action-dotenv-linter@v2.15.0


### PR DESCRIPTION
super-linterでslimイメージを使用することで、CIの実行時間を短縮します。
`dotenv-linter` はslimイメージに含まれていないので、別途実行しています。