### PR TITLE
開発用のYoutube Data APIのユニットが残るようlambda関数 (配信通知) の次回実行時刻調整

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -132,8 +132,8 @@ export async function handler () {
     await sleep(1000)
   }
 
-  // APIリクエストの消費ユニット数 * 24時間 * 60分 * 60秒 / 1日あたりの上限ユニット数 + 1秒
-  const sleepSeconds = Math.ceil((apiUnit * 24 * 60 * 60) / apiUnitLimitPerDay + 1)
+  // APIリクエストの消費ユニット数 * 24時間 * 60分 * 60秒 / (2 * 1日あたりの上限ユニット数) + 1秒
+  const sleepSeconds = Math.ceil((apiUnit * 24 * 60 * 60) / (2 * apiUnitLimitPerDay) + 1)
 
   if (currentNotificationAt !== undefined) {
     await runQuery(


### PR DESCRIPTION
lambda関数 (配信通知) の次回実行時刻を調整することで、1日あたりのYoutube Data APIの上限ユニット数 (10,000) の半分を開発用に残すようにします。