### PR TITLE
Node.jsやnpmのバージョンの方針についてREADMEに記述・textlintのルール修正

### DIFF
--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -23,7 +23,8 @@
     "preset-jtf-style": {
       "1.1.3.箇条書き": false,
       "4.3.1.丸かっこ（）": false,
-      "4.3.2.大かっこ［］": false
+      "4.3.2.大かっこ［］": false,
+      "4.2.7.コロン(：)": false
     },
     "spellcheck-tech-word": true
   }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
 
 ### Node.jsのバージョン
 
-以下の2つのうち、古い方に準拠しています。
+以下の2つのうち、古いほうに準拠しています。
 * dependabotで使用しているバージョン: <https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105>
 * AWS LambdaのNode.jsランタイムで対応している最新バージョン: <https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html>
 

--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
 
 ### Node.jsやnpmのバージョン
 
-dependabotがエラーにならないよう、dependabotで使用しているバージョン (以下参照) に準拠しています。
-https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105
+以下の2つに準拠しています。
+* dependabotで使用しているバージョン: https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105
+* AWS LambdaのNode.jsランタイムで対応しているバージョン: https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html

--- a/README.md
+++ b/README.md
@@ -60,3 +60,10 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
    ```sh
    TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g" | sed -e "s/^main$/latest/g") docker compose up
    ```
+
+## 仕様
+
+### Node.jsやnpmのバージョン
+
+dependabotがエラーにならないよう、dependabotで使用しているバージョン (以下参照) に準拠しています。
+https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105

--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
 
 ## 仕様
 
-### Node.jsやnpmのバージョン
+### Node.jsのバージョン
 
-以下の2つに準拠しています。
-* dependabotで使用しているバージョン: https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105
-* AWS LambdaのNode.jsランタイムで対応しているバージョン: https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html
+以下の2つのうち、古い方に準拠しています。
+* dependabotで使用しているバージョン: <https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105>
+* AWS LambdaのNode.jsランタイムで対応している最新バージョン: <https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html>
+
+### npmのバージョン
+
+dependabotで使用しているバージョンに準拠しています。
+<https://github.com/dependabot/dependabot-core/blob/6e08528c0e3fdbf174d26001124d7c0f7c6bb1b9/Dockerfile#L100-L105>


### PR DESCRIPTION
Node.jsやnpmのバージョンの方針についてREADMEに記述します。
また、全角コロン必須というtextlintのルールは個人的に合点がいかないので無効にします。