### PR TITLE
チャンネルURLとしてユーザーIDを含むものやカスタムURLが与えられた場合の処理修正

### DIFF
--- a/lib/props/function-props.ts
+++ b/lib/props/function-props.ts
@@ -9,6 +9,7 @@ export const functionProps: { [key: string]: NodejsFunctionProps } = {
   },
   reply: {
     functionName: 'youtube_streaming_watcher_reply_function',
-    entry: 'src/reply/index.ts'
+    entry: 'src/reply/index.ts',
+    timeout: cdk.Duration.seconds(10)
   }
 }

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -53,6 +53,7 @@ async function getChannelData (
 
   // チャンネルURLとしてユーザーIDを含むものやカスタムURLが与えられた場合は、ページをスクレイピングしチャンネルIDを取得
   if (id.startsWith('https://www.youtube.com/')) {
+    await postMessage('チャンネルを追加しています。少々お待ちください :eyes:', say)
     console.log('get: ', id)
     const response = await axios.get(id)
     const $ = cheerio.load(response.data)


### PR DESCRIPTION
チャンネルURLとしてユーザーIDを含むものやカスタムURLが与えられた場合の処理を以下のように修正します。
* 処理に6秒程度かかるため、Lambda関数 (リプライ) のタイムアウトを10秒に伸ばす
* 3秒以内にレスポンスを返さないとSlackからリクエストが再送されるため、チャンネルURLとしてユーザーIDを含むものやカスタムURLが与えられた場合は一旦処理中である旨を投稿する