### PR TITLE
重複投稿防止用テーブル追加

### DIFF
--- a/lib/props/dynamodb-table-props.ts
+++ b/lib/props/dynamodb-table-props.ts
@@ -23,5 +23,12 @@ export const dynamoDBTableProps: dynamodb.TableProps[] = [
     readCapacity: 1,
     writeCapacity: 1,
     removalPolicy: cdk.RemovalPolicy.DESTROY
+  },
+  {
+    tableName: 'youtube_streaming_watcher_received_slack_requests',
+    partitionKey: { name: 'ts', type: dynamodb.AttributeType.STRING },
+    readCapacity: 1,
+    writeCapacity: 1,
+    removalPolicy: cdk.RemovalPolicy.DESTROY
   }
 ]


### PR DESCRIPTION
受け取ったSlackからのリクエストの `ts` を保存するテーブルを追加します。
このテーブルにレコードがあるかを確認することで、重複投稿しないようにします。