### PR TITLE
スキーマ定義のremovalPolicyをStack内に移動

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -60,7 +60,9 @@ export class CdkStack extends cdk.Stack {
     const functions = Object.values(functionData)
 
     for (const tableProp of dynamoDBTableProps) {
-      const table = new dynamodb.Table(this, `DynamoDBTable-${tableProp.tableName}`, tableProp)
+      const table = new dynamodb.Table(this, `DynamoDBTable-${tableProp.tableName}`, Object.assign(tableProp, {
+        removalPolicy: cdk.RemovalPolicy.DESTROY
+      }))
       for (const func of functions) {
         table.grant(
           func,

--- a/lib/props/dynamodb-table-props.ts
+++ b/lib/props/dynamodb-table-props.ts
@@ -1,4 +1,3 @@
-import * as cdk from '@aws-cdk/core'
 import * as dynamodb from '@aws-cdk/aws-dynamodb'
 
 export const dynamoDBTableProps: dynamodb.TableProps[] = [
@@ -6,29 +5,25 @@ export const dynamoDBTableProps: dynamodb.TableProps[] = [
     tableName: 'youtube_streaming_watcher_channels',
     partitionKey: { name: 'channel_id', type: dynamodb.AttributeType.STRING },
     readCapacity: 1,
-    writeCapacity: 1,
-    removalPolicy: cdk.RemovalPolicy.DESTROY
+    writeCapacity: 1
   },
   {
     tableName: 'youtube_streaming_watcher_next_notification_times',
     partitionKey: { name: 'next_notification_at', type: dynamodb.AttributeType.STRING },
     readCapacity: 1,
-    writeCapacity: 1,
-    removalPolicy: cdk.RemovalPolicy.DESTROY
+    writeCapacity: 1
   },
   {
     tableName: 'youtube_streaming_watcher_notified_videos',
     partitionKey: { name: 'channel_id', type: dynamodb.AttributeType.STRING },
     sortKey: { name: 'video_id', type: dynamodb.AttributeType.STRING },
     readCapacity: 1,
-    writeCapacity: 1,
-    removalPolicy: cdk.RemovalPolicy.DESTROY
+    writeCapacity: 1
   },
   {
     tableName: 'youtube_streaming_watcher_received_slack_requests',
     partitionKey: { name: 'ts', type: dynamodb.AttributeType.STRING },
     readCapacity: 1,
-    writeCapacity: 1,
-    removalPolicy: cdk.RemovalPolicy.DESTROY
+    writeCapacity: 1
   }
 ]


### PR DESCRIPTION
スキーマ定義の `removalPolicy` は全テーブルで共通、かつ、開発環境では使用しないので、Stack内に移動します。