### PR TITLE
DynamoDB周り修正・調整

### DIFF
--- a/lib/props/dynamodb-table-props.ts
+++ b/lib/props/dynamodb-table-props.ts
@@ -20,7 +20,7 @@ export const dynamoDBTableProps: dynamodb.TableProps[] = [
     tableName: 'youtube_streaming_watcher_notified_videos',
     partitionKey: { name: 'channel_id', type: dynamodb.AttributeType.STRING },
     sortKey: { name: 'video_id', type: dynamodb.AttributeType.STRING },
-    readCapacity: 1,
+    readCapacity: 4,
     writeCapacity: 1,
     removalPolicy: cdk.RemovalPolicy.DESTROY
   },

--- a/lib/props/function-props.ts
+++ b/lib/props/function-props.ts
@@ -5,7 +5,7 @@ export const functionProps: { [key: string]: NodejsFunctionProps } = {
   notify: {
     functionName: 'youtube_streaming_watcher_notify_function',
     entry: 'src/notify/index.ts',
-    timeout: cdk.Duration.minutes(1)
+    timeout: cdk.Duration.seconds(40)
   },
   reply: {
     functionName: 'youtube_streaming_watcher_reply_function',

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -35,12 +35,12 @@ interface RegisteredChannel {
 }
 
 async function isReceivedRequest (ts: string): Promise<boolean> {
-  const receivedRequests = (await runQuery(
+  const receivedRequests = await runQuery(
     'SELECT ts FROM youtube_streaming_watcher_received_slack_requests WHERE ts=?',
     [{ S: ts }]
-  ))?.Items
+  )
 
-  if (receivedRequests !== undefined && receivedRequests.length > 0) {
+  if (receivedRequests.length > 0) {
     console.log('request is already received: ', ts)
     return false
   }
@@ -87,10 +87,10 @@ async function getChannelData (
     id = idContent
   }
 
-  const registeredChannel = (await runQuery(
+  const registeredChannel = await runQuery(
     'SELECT channel_id FROM youtube_streaming_watcher_channels WHERE channel_id=?',
     [{ S: id }]
-  ))?.Items
+  )
   return {
     id,
     exist: registeredChannel !== undefined && registeredChannel.length > 0
@@ -105,9 +105,9 @@ export function setMessageEvents () {
       return
     }
 
-    const channels = (await runQuery('SELECT channel_id FROM youtube_streaming_watcher_channels'))?.Items
+    const channels = await runQuery('SELECT channel_id FROM youtube_streaming_watcher_channels')
 
-    if (channels === undefined || channels.length === 0) {
+    if (channels.length === 0) {
       await say('通知対象のチャンネルはありません')
       return
     }

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -40,117 +40,119 @@ export async function handler () {
     return
   }
 
-  for (let { channel_id: { S: channelId } } of channels) {
-    channelId = channelId as string
+  try {
+    for (let { channel_id: { S: channelId } } of channels) {
+      channelId = channelId as string
 
-    // RSSから新着配信取得
-    const feedParser = new Parser<{}, { id: string }>({ customFields: { item: ['id'] } })
-    const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
-    console.log('get feed: ', feedUrl)
-    const feed = await feedParser.parseURL(feedUrl)
-    const feedItems = feed.items.map(item => {
-      return {
-        videoId: item.id.replace(/^yt:video:/, ''),
-        title: item.title
-      }
-    })
+      // RSSから新着配信取得
+      const feedParser = new Parser<{}, { id: string }>({ customFields: { item: ['id'] } })
+      const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
+      console.log('get feed: ', feedUrl)
+      const feed = await feedParser.parseURL(feedUrl)
+      const feedItems = feed.items.map(item => {
+        return {
+          videoId: item.id.replace(/^yt:video:/, ''),
+          title: item.title
+        }
+      })
 
-    const postedVideos = new Set((await runQuery(
-      'SELECT video_id FROM youtube_streaming_watcher_notified_videos WHERE channel_id=? AND video_id IN (' + feedItems.map(item => '?').join(', ') + ')',
-      [{ S: channelId }].concat(feedItems.map(item => {
-        return { S: item.videoId }
-      }))
-    )).map(item => item.video_id.S))
+      const postedVideos = new Set((await runQuery(
+        'SELECT video_id FROM youtube_streaming_watcher_notified_videos WHERE channel_id=? AND video_id IN (' + feedItems.map(item => '?').join(', ') + ')',
+        [{ S: channelId }].concat(feedItems.map(item => {
+          return { S: item.videoId }
+        }))
+      )).map(item => item.video_id.S))
 
-    for (const feedItem of feedItems) {
-      // 動画ID
-      const videoId = feedItem.videoId
+      for (const feedItem of feedItems) {
+        // 動画ID
+        const videoId = feedItem.videoId
 
-      // 通知済みの配信の場合はスキップ
-      if (postedVideos.has(videoId)) {
-        console.log(`skip: channel_id ${channelId}, video_id: ${videoId}`)
-        continue
-      }
-
-      await runQuery(
-        'INSERT INTO youtube_streaming_watcher_notified_videos VALUE {\'channel_id\': ?, \'video_id\': ?, \'created_at\': ?}',
-        [{ S: channelId }, { S: videoId }, { S: (new Date()).toISOString() }]
-      )
-
-      await sleep(1000)
-
-      // 配信情報
-      const videoResultParams: youtube_v3.Params$Resource$Videos$List = { // eslint-disable-line camelcase
-        part: ['liveStreamingDetails'],
-        id: [videoId]
-      }
-      console.log('call youtubeApi.videos.list: ', videoResultParams)
-      const videoResult = await api.videos.list(videoResultParams)
-      apiUnit++
-      const items = videoResult.data.items
-
-      if (items === undefined) {
-        console.log(`video data can not get: channel_id ${channelId}, video_id: ${videoId}`)
-        continue
-      }
-
-      for (const videoItem of items) {
-        const scheduledStartTime = videoItem.liveStreamingDetails?.scheduledStartTime
-
-        if (scheduledStartTime === undefined || scheduledStartTime === null) {
-          console.log(`start time can not get: channel_id ${channelId}, video_id: ${videoId}`)
+        // 通知済みの配信の場合はスキップ
+        if (postedVideos.has(videoId)) {
+          console.log(`skip: channel_id ${channelId}, video_id: ${videoId}`)
           continue
         }
 
-        const startTime = new Date(Date.parse(scheduledStartTime))
-
-        if (startTime < new Date()) {
-          console.log(`start time has passed: channel_id ${channelId}, video_id: ${videoId}, start_time: ${startTime}`)
-          continue
-        }
+        await runQuery(
+          'INSERT INTO youtube_streaming_watcher_notified_videos VALUE {\'channel_id\': ?, \'video_id\': ?, \'created_at\': ?}',
+          [{ S: channelId }, { S: videoId }, { S: (new Date()).toISOString() }]
+        )
 
         await sleep(1000)
-        const dayOfWeeks = ['日', '月', '火', '水', '木', '金', '土']
 
-        // Slack通知
-        const postMessageParams: ChatPostMessageArguments = {
-          channel: slackChannel,
-          text:
-              'チャンネル名: ' +
-              feed.title +
-              '\n' +
-              '配信名: <https://www.youtube.com/watch?v=' +
-              videoId +
-              '|' +
-              feedItem.title +
-              '>\n' +
-              `開始時刻: ${startTime.getFullYear()}年${startTime.getMonth()}月${startTime.getDate()}日 ` +
-              `(${dayOfWeeks[startTime.getDay()]}) ` +
-              `${startTime.getHours()}時${startTime.getMinutes()}分${startTime.getSeconds()}秒`
+        // 配信情報
+        const videoResultParams: youtube_v3.Params$Resource$Videos$List = { // eslint-disable-line camelcase
+          part: ['liveStreamingDetails'],
+          id: [videoId]
         }
-        console.log('call app.client.chat.postMessage: ', postMessageParams)
-        await slackApp.client.chat.postMessage(postMessageParams)
+        console.log('call youtubeApi.videos.list: ', videoResultParams)
+        const videoResult = await api.videos.list(videoResultParams)
+        apiUnit++
+        const items = videoResult.data.items
+
+        if (items === undefined) {
+          console.log(`video data can not get: channel_id ${channelId}, video_id: ${videoId}`)
+          continue
+        }
+
+        for (const videoItem of items) {
+          const scheduledStartTime = videoItem.liveStreamingDetails?.scheduledStartTime
+
+          if (scheduledStartTime === undefined || scheduledStartTime === null) {
+            console.log(`start time can not get: channel_id ${channelId}, video_id: ${videoId}`)
+            continue
+          }
+
+          const startTime = new Date(Date.parse(scheduledStartTime))
+
+          if (startTime < new Date()) {
+            console.log(`start time has passed: channel_id ${channelId}, video_id: ${videoId}, start_time: ${startTime}`)
+            continue
+          }
+
+          await sleep(1000)
+          const dayOfWeeks = ['日', '月', '火', '水', '木', '金', '土']
+
+          // Slack通知
+          const postMessageParams: ChatPostMessageArguments = {
+            channel: slackChannel,
+            text:
+                'チャンネル名: ' +
+                feed.title +
+                '\n' +
+                '配信名: <https://www.youtube.com/watch?v=' +
+                videoId +
+                '|' +
+                feedItem.title +
+                '>\n' +
+                `開始時刻: ${startTime.getFullYear()}年${startTime.getMonth()}月${startTime.getDate()}日 ` +
+                `(${dayOfWeeks[startTime.getDay()]}) ` +
+                `${startTime.getHours()}時${startTime.getMinutes()}分${startTime.getSeconds()}秒`
+          }
+          console.log('call app.client.chat.postMessage: ', postMessageParams)
+          await slackApp.client.chat.postMessage(postMessageParams)
+        }
       }
+
+      await sleep(1000)
+    }
+  } finally {
+    // APIリクエストの消費ユニット数 * 24時間 * 60分 * 60秒 / 1日あたりの上限ユニット数 + 1秒
+    const sleepSeconds = Math.ceil((apiUnit * 24 * 60 * 60) / apiUnitLimitPerDay + 1)
+
+    if (currentNotificationAt !== undefined) {
+      await runQuery(
+        'DELETE FROM youtube_streaming_watcher_next_notification_times WHERE next_notification_at=?',
+        [{ S: currentNotificationAt }]
+      )
     }
 
-    await sleep(1000)
-  }
-
-  // APIリクエストの消費ユニット数 * 24時間 * 60分 * 60秒 / 1日あたりの上限ユニット数 + 1秒
-  const sleepSeconds = Math.ceil((apiUnit * 24 * 60 * 60) / apiUnitLimitPerDay + 1)
-
-  if (currentNotificationAt !== undefined) {
+    const nextNotificationAt = new Date()
+    nextNotificationAt.setSeconds(nextNotificationAt.getSeconds() + sleepSeconds)
     await runQuery(
-      'DELETE FROM youtube_streaming_watcher_next_notification_times WHERE next_notification_at=?',
-      [{ S: currentNotificationAt }]
+      'INSERT INTO youtube_streaming_watcher_next_notification_times VALUE {\'next_notification_at\': ?}',
+      [{ S: nextNotificationAt.toISOString() }]
     )
+    console.log('next notify at ', nextNotificationAt)
   }
-
-  const nextNotificationAt = new Date()
-  nextNotificationAt.setSeconds(nextNotificationAt.getSeconds() + sleepSeconds)
-  await runQuery(
-    'INSERT INTO youtube_streaming_watcher_next_notification_times VALUE {\'next_notification_at\': ?}',
-    [{ S: nextNotificationAt.toISOString() }]
-  )
-  console.log('next notify at ', nextNotificationAt)
 }

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -10,9 +10,9 @@ const apiUnitLimitPerDay = 10000
 
 export async function handler () {
   let currentNotificationAt: string | undefined
-  const currentNotificationAtItems = (await runQuery('SELECT next_notification_at FROM youtube_streaming_watcher_next_notification_times'))?.Items
+  const currentNotificationAtItems = await runQuery('SELECT next_notification_at FROM youtube_streaming_watcher_next_notification_times')
 
-  if (currentNotificationAtItems !== undefined && currentNotificationAtItems.length > 0) {
+  if (currentNotificationAtItems.length > 0) {
     currentNotificationAt = currentNotificationAtItems[0].next_notification_at.S
     if (currentNotificationAt !== undefined && new Date() < new Date(currentNotificationAt)) {
       console.log('next notification time has not come yet.')
@@ -34,9 +34,9 @@ export async function handler () {
   // APIごとの消費コスト: https://developers.google.com/youtube/v3/determine_quota_cost
   let apiUnit = 0
 
-  const channels = (await runQuery('SELECT channel_id FROM youtube_streaming_watcher_channels'))?.Items
+  const channels = await runQuery('SELECT channel_id FROM youtube_streaming_watcher_channels')
 
-  if (channels === undefined) {
+  if (channels.length === 0) {
     return
   }
 
@@ -60,7 +60,7 @@ export async function handler () {
       [{ S: channelId }].concat(feedItems.map(item => {
         return { S: item.videoId }
       }))
-    ))?.Items?.map(item => item.video_id.S))
+    )).map(item => item.video_id.S))
 
     for (const feedItem of feedItems) {
       // 動画ID


### PR DESCRIPTION
DynamoDB周りで以下の通り修正・調整します。
* DynamoDBは1クエリあたり1MBまでしかデータを取得できないので、ページング対応して全データ取得できるようにする: https://github.com/dev-hato/youtube_streaming_watcher/commit/05d1da225504614d2b97fe37facee9945d9e43bf
* lambda関数 (配信通知) で例外が発生すると、次回実行時刻を記録せずに終了してしまい、Youtube Data APIの消費ユニットを正しくコントロールできないので、例外発生時でも次回実行時刻は記録するようにする: https://github.com/dev-hato/youtube_streaming_watcher/commit/e210eff2daf8837932265de706de0df855362afa
* `youtube_streaming_watcher_notified_videos` (通知済み配信一覧) の読み込み周りでキャパシティを超えているので、リードキャパシティを4に変更: https://github.com/dev-hato/youtube_streaming_watcher/commit/0c582e8d170bad6979ffb07eb45c476eeeecfbd2
* 上記変更を反映した結果、lambda関数 (配信通知) は20秒程度の実行時間になるようなので、タイムアウトを40秒に変更: https://github.com/dev-hato/youtube_streaming_watcher/commit/e2bd646eb9ec961dc3833da41e7047cdde1cb85b