### PR TITLE
Dockerイメージをbullseyeベースに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.0-buster-slim AS base
+FROM node:14.19.0-bullseye-slim AS base
 
 WORKDIR /usr/app
 COPY .node-version .


### PR DESCRIPTION
Debianの最新バージョンはbullseyeなので、bullseyeベースに変更します。