### PR TITLE
権限・タイムアウト修正

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -79,7 +79,8 @@ export class CdkStack extends cdk.Stack {
           'dynamodb:DescribeTable',
           'dynamodb:PartiQLInsert',
           'dynamodb:PartiQLSelect',
-          'dynamodb:PartiQLDelete'
+          'dynamodb:PartiQLDelete',
+          'dynamodb:PartiQLUpdate'
         )
       }
 

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -191,7 +191,7 @@ export class CdkStack extends cdk.Stack {
             cdkSecret,
             slackSecret,
             youtubeSecret
-          ].map(s => s.secretArn)
+          ].map(s => s.secretArn + '*')
         }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,

--- a/lib/props/function-props.ts
+++ b/lib/props/function-props.ts
@@ -5,7 +5,7 @@ export const functionProps: { [key: string]: NodejsFunctionProps } = {
   notify: {
     functionName: 'youtube_streaming_watcher_notify_function',
     entry: 'src/notify/index.ts',
-    timeout: cdk.Duration.seconds(40)
+    timeout: cdk.Duration.minutes(5)
   },
   reply: {
     functionName: 'youtube_streaming_watcher_reply_function',


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/runs/5240373406?check_suite_focus=true

```
User: arn:aws:sts::***:assumed-role/youtube_streaming_watcher_cdk_deploy/GitHubActions is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:***:***:secret:youtube_streaming_watcher_slack because no identity-based policy allows the secretsmanager:GetSecretValue action
```

secretmanagerの場合、 `arn:aws:secretsmanager:***:***:secret:youtube_streaming_watcher_slack` の後ろにプレフィックスがつくため、デプロイロールのIAMポリシーをそれに対応する形に修正します。

また、 https://github.com/dev-hato/youtube_streaming_watcher/pull/75 に伴って以下を修正します。
* DynamoDBに対するUPDATEを行うようになったため、lambda関数から `dynamodb:PartiQLUpdate` できるようにする
* lambda関数 (配信通知) のタイムアウトを5分に伸ばす

手動でデプロイしているため、差分がないのが正しいです。