### PR TITLE
配信データ挿入クエリ修正

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -149,7 +149,7 @@ export async function handler () {
           if (startTimeStr === undefined) { // データがない場合はINSERTする
             await runQuery(
               'INSERT INTO youtube_streaming_watcher_notified_videos VALUE {\'channel_id\': ?, \'video_id\': ?, \'created_at\': ?, \'start_time\': ?, \'notify_mode\': ?}',
-              [{ S: channelId }, { S: videoId }, { S: now.toISOString() }, { S: startTimeStr }, { S: notifyMode }]
+              [{ S: channelId }, { S: videoId }, { S: now.toISOString() }, { S: newStartTimeStr }, { S: notifyMode }]
             )
           } else if (startTimeStr === '') { // start_timeやnotify_modeが欠けている古いデータについてはUPDATEする
             await runQuery(


### PR DESCRIPTION
配信データ挿入のクエリでAPIから取得した配信開始時刻を挿入するように修正します。

```
2022-02-18T12:15:58.400Z	...	INFO	run query:  {
  Statement: "INSERT INTO youtube_streaming_watcher_notified_videos VALUE {'channel_id': ?, 'video_id': ?, 'created_at': ?, 'start_time': ?, 'notify_mode': ?}",
  Parameters: [
    { S: '...' },
    { S: '...' },
    { S: '...' },
    { S: undefined },
    { S: 'Registered' }
  ]
}
...
2022-02-18T12:15:58.472Z	...	ERROR	Invoke Error 	{
    "errorType": "TypeError",
    "errorMessage": "Cannot read property '0' of undefined",
    "stack": [
        "TypeError: Cannot read property '0' of undefined",
        "    at Object.e.visit (/var/task/index.js:88:27936)",
        "    at Ky (/var/task/index.js:88:132719)",
        "    at /var/task/index.js:88:151065",
        "    at Array.map (<anonymous>)",
        "    at vk (/var/task/index.js:88:151044)",
        "    at cuo (/var/task/index.js:88:142529)",
        "    at Object.Cro [as serializeAws_json1_0ExecuteStatementCommand] (/var/task/index.js:88:62134)",
        "    at serialize (/var/task/index.js:88:227399)",
        "    at /var/task/index.js:83:5968897",
        "    at /var/task/index.js:88:311799"
    ]
}
```