### PR TITLE
Lambda関数一覧を変数を参照する形にリファクタリング

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -224,7 +224,7 @@ export class CdkStack extends cdk.Stack {
             'lambda:UpdateFunctionCode',
             'lambda:UpdateFunctionConfiguration'
           ],
-          resources: Object.values(functionData).map(f => f.functionArn)
+          resources: functions.map(f => f.functionArn)
         }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,


### PR DESCRIPTION
Lambda関数一覧は変数として定義されているので、それを参照する形にリファクタリングします。
差分が出ないのが正です。