### PR TITLE
CI: IAMロールのARNをAWSアカウントID以外埋め込む形で与える

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
-          role-to-assume: ${{ secrets.AWS_CDK_DEPLOY_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/youtube_streaming_watcher_cdk_deploy
           aws-region: ${{ secrets.AWS_REGION }}
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.1

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -14,7 +14,7 @@ jobs:
       - run: echo "${{ secrets.AWS_REGION }}"
       - uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
-          role-to-assume: ${{ secrets.AWS_CDK_DIFF_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/youtube_streaming_watcher_cdk_diff
           aws-region: ${{ secrets.AWS_REGION }}
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.1


### PR DESCRIPTION
IAMロールの名前自体はCDKの方で決め打ちしているので、IAMロールのARNをAWSアカウントID以外埋め込む形に変更します。