### PR TITLE
cdk-diffでエラーが発生した際にもコメントする

### DIFF
--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -30,6 +30,7 @@ jobs:
         id: diff
         continue-on-error: true
         run: |
+          set +e
           result=$(npx cdk diff 2>&1)
           echo -e "${result}"
           result="${result//'%'/'%25'}"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -28,6 +28,7 @@ jobs:
       # 差分があったときは差分を出力する
       - name: Show diff
         id: diff
+        continue-on-error: true
         run: |
           result=$(npx cdk diff 2>&1)
           echo -e "${result}"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -54,3 +54,5 @@ jobs:
               issue_number: context.issue.number,
               body,
             })
+      - if: steps.diff.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -32,11 +32,13 @@ jobs:
         run: |
           set +e
           result=$(npx cdk diff 2>&1)
+          exit_code=${?}
           echo -e "${result}"
           result="${result//'%'/'%25'}"
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
+          exit ${exit_code}
       - name: Comment
         uses: actions/github-script@v6
         env:


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/runs/5257148702?check_suite_focus=true

`cdk diff` 実行時にエラーが発生した場合にもコメントするようにします。

エラーが発生した際の例: https://github.com/dev-hato/youtube_streaming_watcher/pull/99#issuecomment-1045994029, https://github.com/dev-hato/youtube_streaming_watcher/runs/5258306533?check_suite_focus=true