### PR TITLE
lambda関数のエラー通知追加

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -1,5 +1,8 @@
 import * as cdk from '@aws-cdk/core'
 import * as apigateway from '@aws-cdk/aws-apigateway'
+import * as chatbot from '@aws-cdk/aws-chatbot'
+import * as cloudwatch from '@aws-cdk/aws-cloudwatch'
+import * as cloudwatchActions from '@aws-cdk/aws-cloudwatch-actions'
 import * as dynamodb from '@aws-cdk/aws-dynamodb'
 import * as events from '@aws-cdk/aws-events'
 import * as iam from '@aws-cdk/aws-iam'
@@ -8,6 +11,7 @@ import * as lambda from '@aws-cdk/aws-lambda'
 import * as lambdaNode from '@aws-cdk/aws-lambda-nodejs'
 import * as logs from '@aws-cdk/aws-logs'
 import * as secretmanager from '@aws-cdk/aws-secretsmanager'
+import * as sns from '@aws-cdk/aws-sns'
 import { dynamoDBTableProps } from './props/dynamodb-table-props'
 import { rate } from './props/events-rule-props'
 import { functionProps } from './props/function-props'
@@ -26,6 +30,11 @@ export class CdkStack extends cdk.Stack {
       'Secret-slack',
       'youtube_streaming_watcher_slack'
     )
+    const slackAlertSecret = secretmanager.Secret.fromSecretNameV2(
+      this,
+      'Secret-slack_alert',
+      'youtube_streaming_watcher_slack_alert'
+    )
     const youtubeSecret = secretmanager.Secret.fromSecretNameV2(
       this,
       'Secret-youtube',
@@ -38,14 +47,40 @@ export class CdkStack extends cdk.Stack {
       TZ: 'Asia/Tokyo',
       YOUTUBE_API_KEY: youtubeSecret.secretValueFromJson('youtube_api_key').toString()
     }
-    const functionData = Object.fromEntries(Object.entries(functionProps).map(([key, value]) => [
+    const functionDataEntities: [string, lambdaNode.NodejsFunction][] = Object.entries(functionProps).map(([key, value]) => [
       key,
       new lambdaNode.NodejsFunction(this, `Function-${key}`, Object.assign(value, {
         runtime: lambda.Runtime.NODEJS_14_X,
         bundling: { minify: true },
         environment
       }))
-    ]))
+    ])
+    const functionData = Object.fromEntries(functionDataEntities)
+    const lambdaSNSTopic = new sns.Topic(this, 'SNSTopic-lambda')
+    const lambdaSNSTopicAction = new cloudwatchActions.SnsAction(lambdaSNSTopic)
+    const alarmArns = []
+
+    for (const [key, func] of functionDataEntities) {
+      const alarm = new cloudwatch.Alarm(this, `Alarm-lambda_${key}`, {
+        evaluationPeriods: 1,
+        metric: func.metric('Errors', {
+          statistic: cloudwatch.Statistic.AVERAGE,
+          period: cdk.Duration.minutes(5)
+        }),
+        threshold: 0,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD
+      })
+      alarm.addOkAction(lambdaSNSTopicAction)
+      alarm.addAlarmAction(lambdaSNSTopicAction)
+      alarmArns.push(alarm.alarmArn)
+    }
+
+    const chatbotSlackChannelConfig = new chatbot.SlackChannelConfiguration(this, 'ChatbotSlackChannelConfig-default', {
+      slackChannelConfigurationName: 'youtube_streaming_watcher_slack',
+      slackWorkspaceId: slackAlertSecret.secretValueFromJson('workspace_id').toString(),
+      slackChannelId: slackAlertSecret.secretValueFromJson('channel_id').toString(),
+      notificationTopics: [lambdaSNSTopic]
+    })
     const rule = new events.Rule(this, 'EventsRule-notify', {
       schedule: events.Schedule.rate(rate),
       targets: [new targets.LambdaFunction(functionData.notify)]
@@ -259,7 +294,7 @@ export class CdkStack extends cdk.Stack {
             'SNS:CreateTopic',
             'SNS:DeleteTopic'
           ],
-          resources: ['arn:aws:sns:ap-northeast-1:562744081179:Stack-youtube-streaming-watcher-SNSTopiclambdaA110B4B4-*']
+          resources: [lambdaSNSTopic.topicArn]
         }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
@@ -267,12 +302,12 @@ export class CdkStack extends cdk.Stack {
             'cloudwatch:PutMetricAlarm',
             'cloudwatch:DeleteAlarms'
           ],
-          resources: ['arn:aws:cloudwatch:ap-northeast-1:562744081179:alarm:Stack-youtube-streaming-watcher-*']
+          resources: alarmArns
         }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ['chatbot:CreateSlackChannelConfiguration'],
-          resources: ['arn:aws:chatbot:ap-southeast-1:562744081179:chat-configuration/slack-channel/youtube_streaming_watcher_slack']
+          resources: [chatbotSlackChannelConfig.slackChannelConfigurationArn]
         })
       ]
     }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "youtube_streaming_watcher",
       "dependencies": {
         "@aws-cdk/aws-apigateway": "^1.145.0",
+        "@aws-cdk/aws-chatbot": "^1.145.0",
+        "@aws-cdk/aws-cloudwatch": "^1.145.0",
+        "@aws-cdk/aws-cloudwatch-actions": "^1.145.0",
         "@aws-cdk/aws-dynamodb": "^1.145.0",
         "@aws-cdk/aws-events": "^1.145.0",
         "@aws-cdk/aws-events-targets": "^1.145.0",
@@ -15,6 +18,7 @@
         "@aws-cdk/aws-lambda-nodejs": "^1.145.0",
         "@aws-cdk/aws-logs": "^1.145.0",
         "@aws-cdk/aws-secretsmanager": "^1.145.0",
+        "@aws-cdk/aws-sns": "^1.145.0",
         "@aws-cdk/core": "^1.145.0",
         "@aws-sdk/client-dynamodb": "^3.52.0",
         "@slack/bolt": "^3.9.0",
@@ -265,6 +269,32 @@
         "constructs": "^3.3.69"
       }
     },
+    "node_modules/@aws-cdk/aws-chatbot": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-chatbot/-/aws-chatbot-1.145.0.tgz",
+      "integrity": "sha512-nxo2VHERokHBax1YpOmOye2kpFZZzqrPHwdxb01hbUa6R6HBltksQEXsZdraz/Lbc9Bz9GnGtmVcBuwNKZbSDQ==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-codestarnotifications": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-logs": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-codestarnotifications": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-logs": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "node_modules/@aws-cdk/aws-cloudformation": {
       "version": "1.145.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.145.0.tgz",
@@ -339,6 +369,32 @@
       },
       "peerDependencies": {
         "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudwatch-actions": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.145.0.tgz",
+      "integrity": "sha512-F2sXQ0EgO2pNOZ5mvjW4jpH4oOzdAKRqUPuJp0LWE26+jDGFKbOPwWUwyLyIOmERc8LugrYak2cDGVR5XvX8kg==",
+      "dependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.145.0",
+        "@aws-cdk/aws-autoscaling": "1.145.0",
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.145.0",
+        "@aws-cdk/aws-autoscaling": "1.145.0",
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
         "@aws-cdk/core": "1.145.0",
         "constructs": "^3.3.69"
       }
@@ -14732,6 +14788,20 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-chatbot": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-chatbot/-/aws-chatbot-1.145.0.tgz",
+      "integrity": "sha512-nxo2VHERokHBax1YpOmOye2kpFZZzqrPHwdxb01hbUa6R6HBltksQEXsZdraz/Lbc9Bz9GnGtmVcBuwNKZbSDQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-codestarnotifications": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-logs": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-cloudformation": {
       "version": "1.145.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.145.0.tgz",
@@ -14770,6 +14840,20 @@
       "integrity": "sha512-RRAz/q7mcUQJdkao3GSpmV08Qn0Ip9IKJ/iBP7FmmIlIA0k/9hI9XlYXi1NxDrsAExaC7Vvq/pfct7rZ3SrRfQ==",
       "requires": {
         "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch-actions": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.145.0.tgz",
+      "integrity": "sha512-F2sXQ0EgO2pNOZ5mvjW4jpH4oOzdAKRqUPuJp0LWE26+jDGFKbOPwWUwyLyIOmERc8LugrYak2cDGVR5XvX8kg==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.145.0",
+        "@aws-cdk/aws-autoscaling": "1.145.0",
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
         "@aws-cdk/core": "1.145.0",
         "constructs": "^3.3.69"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.145.0",
+    "@aws-cdk/aws-chatbot": "^1.145.0",
+    "@aws-cdk/aws-cloudwatch": "^1.145.0",
+    "@aws-cdk/aws-cloudwatch-actions": "^1.145.0",
     "@aws-cdk/aws-dynamodb": "^1.145.0",
     "@aws-cdk/aws-events": "^1.145.0",
     "@aws-cdk/aws-events-targets": "^1.145.0",
@@ -52,6 +55,7 @@
     "@aws-cdk/aws-lambda-nodejs": "^1.145.0",
     "@aws-cdk/aws-logs": "^1.145.0",
     "@aws-cdk/aws-secretsmanager": "^1.145.0",
+    "@aws-cdk/aws-sns": "^1.145.0",
     "@aws-cdk/core": "^1.145.0",
     "@aws-sdk/client-dynamodb": "^3.52.0",
     "@slack/bolt": "^3.9.0",


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/issues/84

lambda関数のエラー通知をSlackに流すようにします。
https://github.com/dev-hato/youtube_streaming_watcher/pull/102 を前提としているので、 https://github.com/dev-hato/youtube_streaming_watcher/pull/102 に向けています。