### PR TITLE
lambda関数のエラー通知追加

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -96,6 +96,7 @@ export class CdkStack extends cdk.Stack {
     const managedPolicies: iam.IManagedPolicy[] = [
       'AmazonDynamoDBReadOnlyAccess',
       'AmazonS3ReadOnlyAccess',
+      'AmazonSNSReadOnlyAccess',
       'AWSCloudFormationReadOnlyAccess',
       'AmazonEventBridgeReadOnlyAccess',
       'AWSLambda_ReadOnlyAccess',
@@ -251,6 +252,27 @@ export class CdkStack extends cdk.Stack {
             'logs:DeleteLogGroup'
           ],
           resources: [apiAccessLogGroup.logGroupArn]
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
+            'SNS:CreateTopic',
+            'SNS:DeleteTopic'
+          ],
+          resources: [`arn:aws:sns:${this.region}:${this.account}:Stack-youtube-streaming-watcher-SNSTopiclambda*`]
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
+            'cloudwatch:PutMetricAlarm',
+            'cloudwatch:DeleteAlarms'
+          ],
+          resources: [`arn:aws:cloudwatch:${this.region}:${this.account}:alarm:Stack-youtube-streaming-watcher-*`]
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['chatbot:CreateSlackChannelConfiguration'],
+          resources: [`arn:aws:chatbot:*:${this.account}:chat-configuration/slack-channel/youtube_streaming_watcher_slack`]
         })
       ]
     }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "youtube_streaming_watcher",
       "dependencies": {
         "@aws-cdk/aws-apigateway": "^1.145.0",
+        "@aws-cdk/aws-chatbot": "^1.145.0",
+        "@aws-cdk/aws-cloudwatch": "^1.145.0",
+        "@aws-cdk/aws-cloudwatch-actions": "^1.145.0",
         "@aws-cdk/aws-dynamodb": "^1.145.0",
         "@aws-cdk/aws-events": "^1.145.0",
         "@aws-cdk/aws-events-targets": "^1.145.0",
@@ -15,6 +18,7 @@
         "@aws-cdk/aws-lambda-nodejs": "^1.145.0",
         "@aws-cdk/aws-logs": "^1.145.0",
         "@aws-cdk/aws-secretsmanager": "^1.145.0",
+        "@aws-cdk/aws-sns": "^1.145.0",
         "@aws-cdk/core": "^1.145.0",
         "@aws-sdk/client-dynamodb": "^3.52.0",
         "@slack/bolt": "^3.9.0",
@@ -265,6 +269,32 @@
         "constructs": "^3.3.69"
       }
     },
+    "node_modules/@aws-cdk/aws-chatbot": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-chatbot/-/aws-chatbot-1.145.0.tgz",
+      "integrity": "sha512-nxo2VHERokHBax1YpOmOye2kpFZZzqrPHwdxb01hbUa6R6HBltksQEXsZdraz/Lbc9Bz9GnGtmVcBuwNKZbSDQ==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-codestarnotifications": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-logs": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-codestarnotifications": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-logs": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "node_modules/@aws-cdk/aws-cloudformation": {
       "version": "1.145.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.145.0.tgz",
@@ -339,6 +369,32 @@
       },
       "peerDependencies": {
         "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudwatch-actions": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.145.0.tgz",
+      "integrity": "sha512-F2sXQ0EgO2pNOZ5mvjW4jpH4oOzdAKRqUPuJp0LWE26+jDGFKbOPwWUwyLyIOmERc8LugrYak2cDGVR5XvX8kg==",
+      "dependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.145.0",
+        "@aws-cdk/aws-autoscaling": "1.145.0",
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.145.0",
+        "@aws-cdk/aws-autoscaling": "1.145.0",
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
         "@aws-cdk/core": "1.145.0",
         "constructs": "^3.3.69"
       }
@@ -14732,6 +14788,20 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-chatbot": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-chatbot/-/aws-chatbot-1.145.0.tgz",
+      "integrity": "sha512-nxo2VHERokHBax1YpOmOye2kpFZZzqrPHwdxb01hbUa6R6HBltksQEXsZdraz/Lbc9Bz9GnGtmVcBuwNKZbSDQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-codestarnotifications": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-logs": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-cloudformation": {
       "version": "1.145.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.145.0.tgz",
@@ -14770,6 +14840,20 @@
       "integrity": "sha512-RRAz/q7mcUQJdkao3GSpmV08Qn0Ip9IKJ/iBP7FmmIlIA0k/9hI9XlYXi1NxDrsAExaC7Vvq/pfct7rZ3SrRfQ==",
       "requires": {
         "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/core": "1.145.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch-actions": {
+      "version": "1.145.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.145.0.tgz",
+      "integrity": "sha512-F2sXQ0EgO2pNOZ5mvjW4jpH4oOzdAKRqUPuJp0LWE26+jDGFKbOPwWUwyLyIOmERc8LugrYak2cDGVR5XvX8kg==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.145.0",
+        "@aws-cdk/aws-autoscaling": "1.145.0",
+        "@aws-cdk/aws-cloudwatch": "1.145.0",
+        "@aws-cdk/aws-iam": "1.145.0",
+        "@aws-cdk/aws-sns": "1.145.0",
         "@aws-cdk/core": "1.145.0",
         "constructs": "^3.3.69"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.145.0",
+    "@aws-cdk/aws-chatbot": "^1.145.0",
+    "@aws-cdk/aws-cloudwatch": "^1.145.0",
+    "@aws-cdk/aws-cloudwatch-actions": "^1.145.0",
     "@aws-cdk/aws-dynamodb": "^1.145.0",
     "@aws-cdk/aws-events": "^1.145.0",
     "@aws-cdk/aws-events-targets": "^1.145.0",
@@ -52,6 +55,7 @@
     "@aws-cdk/aws-lambda-nodejs": "^1.145.0",
     "@aws-cdk/aws-logs": "^1.145.0",
     "@aws-cdk/aws-secretsmanager": "^1.145.0",
+    "@aws-cdk/aws-sns": "^1.145.0",
     "@aws-cdk/core": "^1.145.0",
     "@aws-sdk/client-dynamodb": "^3.52.0",
     "@slack/bolt": "^3.9.0",


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/issues/84

lambda関数のエラー通知をSlackに流すようにします。
https://github.com/dev-hato/youtube_streaming_watcher/pull/104 デプロイ後にデプロイするので、 https://github.com/dev-hato/youtube_streaming_watcher/pull/104 に向けています。