### PR TITLE
登録済み配信取得や配信情報取得をチャンネルごと実行する

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -225,12 +225,12 @@ export async function handler () {
         const postMessageParams: ChatPostMessageArguments = {
           channel: slackChannel,
           text:
-                        header +
-                        `チャンネル名: <https://www.youtube.com/channel/${channelId}|${cd.title}>\n` +
-                        `配信名: <https://www.youtube.com/watch?v=${videoId}|${vd.title}>\n` +
-                        `開始時刻: ${startTime.getFullYear()}年${startTime.getMonth() + 1}月${startTime.getDate()}日 ` +
-                        `(${dayOfWeeks[startTime.getDay()]}) ` +
-                        `${startTime.getHours()}時${startTime.getMinutes()}分${startTime.getSeconds()}秒`
+              header +
+              `チャンネル名: <https://www.youtube.com/channel/${channelId}|${cd.title}>\n` +
+              `配信名: <https://www.youtube.com/watch?v=${videoId}|${vd.title}>\n` +
+              `開始時刻: ${startTime.getFullYear()}年${startTime.getMonth() + 1}月${startTime.getDate()}日 ` +
+              `(${dayOfWeeks[startTime.getDay()]}) ` +
+              `${startTime.getHours()}時${startTime.getMinutes()}分${startTime.getSeconds()}秒`
         }
         console.log('call app.client.chat.postMessage: ', postMessageParams)
         await slackApp.client.chat.postMessage(postMessageParams)


### PR DESCRIPTION
登録済み配信取得のクエリでの読み取り処理が多すぎと怒られたので、チャンネルごとに実行するようにします。
その後の配信情報取得もうまくいかなかったので、こちらについても同様に対応します。

```
INFO	run query:  {
  Statement: 'SELECT channel_id, video_id, start_time, notify_mode FROM youtube_streaming_watcher_notified_videos WHERE (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) OR (channel_id=? AND video_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?))',
  Parameters: [...]
...
ERROR	Invoke Error 	{
    "errorType": "ValidationException",
    "errorMessage": "Too many decomposed read operations for a given query.",
    "trace": [
        "ValidationException: Too many decomposed read operations for a given query.",
        "    at nuo (/var/task/index.js:88:95405)",
        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
        "    at async /var/task/index.js:83:5968623",
        "    at async /var/task/index.js:99:4211",
        "    at async rVe.retry (/var/task/index.js:88:327679)",
        "    at async /var/task/index.js:88:311809",
        "    at async oy (/var/task/index.js:202:3146)",
        "    at async Runtime.oCo [as handler] (/var/task/index.js:202:4828)"
    ]
}
```