### PR TITLE
CloudWatch Alarmで欠損データを無視するよう設定する

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -68,7 +68,8 @@ export class CdkStack extends cdk.Stack {
           period: cdk.Duration.minutes(5)
         }),
         threshold: 0,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE
       })
       alarm.addOkAction(lambdaSNSTopicAction)
       alarm.addAlarmAction(lambdaSNSTopicAction)


### PR DESCRIPTION
lambda関数 (リプライ) を実行する度にCloudWatch Alarmが正常通知を飛ばしてきて邪魔なので、欠損データを無視する (Alarmの状態を維持する) よう設定します。

https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data