### PR TITLE
updated_timeがundefinedな場合を考慮する

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -112,7 +112,7 @@ export async function handler () {
 
         // 登録通知が完了している場合
         if (startTimeStr !== undefined) {
-          const updateTime = item.updated_time.S
+          const updateTime = item.updated_time?.S
 
           if (updateTime !== undefined && new Date(updateTime) < notifyVideoData[channelId].videos[videoId].updatedTime) {
             notifyVideoData[channelId].videos[videoId].isUpdated = true


### PR DESCRIPTION
`updated_time` がundefinedな場合を考慮できていなかったので修正します。

```
ERROR	Invoke Error 	{
    "errorType": "TypeError",
    "errorMessage": "Cannot read property 'S' of undefined",
    "stack": [
        "TypeError: Cannot read property 'S' of undefined",
        "    at Runtime.oCo [as handler] (/var/task/index.js:202:5308)",
        "    at runMicrotasks (<anonymous>)",
        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)"
    ]
}
```