### PR TITLE
非推奨のtextlintルール削除

### DIFF
--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -25,7 +25,6 @@
       "4.3.1.丸かっこ（）": false,
       "4.3.2.大かっこ［］": false,
       "4.2.7.コロン(：)": false
-    },
-    "spellcheck-tech-word": true
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "textlint-rule-preset-ja-spacing": "^2.2.0",
         "textlint-rule-preset-ja-technical-writing": "^7.0.0",
         "textlint-rule-preset-jtf-style": "^2.3.12",
-        "textlint-rule-spellcheck-tech-word": "^5.0.0",
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5"
       },
@@ -12005,16 +12004,6 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
-    "node_modules/spellcheck-technical-word": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spellcheck-technical-word/-/spellcheck-technical-word-2.0.0.tgz",
-      "integrity": "sha1-ywN2uLvaYjm2vgCYeM+BzxcIBQM=",
-      "dev": true,
-      "dependencies": {
-        "structured-source": "^3.0.2",
-        "technical-word-rules": "^1.4.2"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -12181,12 +12170,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/technical-word-rules": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/technical-word-rules/-/technical-word-rules-1.9.5.tgz",
-      "integrity": "sha512-2sqzeb3aE23GtIO9fL9sDbqdt4vnoks7nWZRUgqEvYkjEmmQjrnVfl3WTURBZFrpgAXBNk0AMhWCj+17mzYXhw==",
       "dev": true
     },
     "node_modules/text-table": {
@@ -13877,19 +13860,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/textlint-rule-spellcheck-tech-word": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-spellcheck-tech-word/-/textlint-rule-spellcheck-tech-word-5.0.0.tgz",
-      "integrity": "sha1-J5vjH9SzleH4e0oe9jkvFQSJTEI=",
-      "dev": true,
-      "dependencies": {
-        "spellcheck-technical-word": "^2.0.0",
-        "textlint-rule-helper": "^1.1.2"
-      },
-      "peerDependencies": {
-        "textlint": ">= 5.6.0"
       }
     },
     "node_modules/textlint-util-to-string": {
@@ -24127,16 +24097,6 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
-    "spellcheck-technical-word": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spellcheck-technical-word/-/spellcheck-technical-word-2.0.0.tgz",
-      "integrity": "sha1-ywN2uLvaYjm2vgCYeM+BzxcIBQM=",
-      "dev": true,
-      "requires": {
-        "structured-source": "^3.0.2",
-        "technical-word-rules": "^1.4.2"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -24266,12 +24226,6 @@
           "dev": true
         }
       }
-    },
-    "technical-word-rules": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/technical-word-rules/-/technical-word-rules-1.9.5.tgz",
-      "integrity": "sha512-2sqzeb3aE23GtIO9fL9sDbqdt4vnoks7nWZRUgqEvYkjEmmQjrnVfl3WTURBZFrpgAXBNk0AMhWCj+17mzYXhw==",
-      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -25818,16 +25772,6 @@
             "unist-util-visit-parents": "^3.0.0"
           }
         }
-      }
-    },
-    "textlint-rule-spellcheck-tech-word": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-spellcheck-tech-word/-/textlint-rule-spellcheck-tech-word-5.0.0.tgz",
-      "integrity": "sha1-J5vjH9SzleH4e0oe9jkvFQSJTEI=",
-      "dev": true,
-      "requires": {
-        "spellcheck-technical-word": "^2.0.0",
-        "textlint-rule-helper": "^1.1.2"
       }
     },
     "textlint-util-to-string": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^7.0.0",
     "textlint-rule-preset-jtf-style": "^2.3.12",
-    "textlint-rule-spellcheck-tech-word": "^5.0.0",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5"
   },


### PR DESCRIPTION
https://github.com/azu/textlint-rule-spellcheck-tech-word

>Deprecated: [Proofdict](https://github.com/proofdict/proofdict)を使っているためメンテナンスしていません。

とのことなので `textlint-rule-spellcheck-tech-word` を削除します。