### PR TITLE
配信済みの配信を配信情報取得の対象から除外する

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.2.7
+    rev: v8.3.0
     hooks:
       - id: gitleaks

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -114,17 +114,10 @@ export async function handler () {
 
         // 登録通知が完了している場合
         if (startTimeStr !== undefined) {
-          const updateTime = item.updated_time?.S
-
-          if (updateTime !== undefined && new Date(updateTime) < notifyVideoData[channelId].videos[videoId].updatedTime) {
-            notifyVideoData[channelId].videos[videoId].isUpdated = true
-          } else {
-            needGetStartTimeVideos.delete(videoId)
-          }
-
           const startTime = new Date(startTimeStr)
           const oneHourAgoTime = new Date(startTime)
           oneHourAgoTime.setHours(oneHourAgoTime.getHours() - 1)
+          const updateTime = item.updated_time?.S
           const now = new Date()
 
           // 以下のいずれかを満たしている場合は通知しない
@@ -133,8 +126,13 @@ export async function handler () {
           // * 配信開始まで1時間以内でリマインド通知が完了している
           if (now < oneHourAgoTime || startTime < now || notifyMode === NotifyMode.NotifyRemind) {
             console.log(`skip: channel_id ${channelId}, video_id: ${videoId}`)
+            needGetStartTimeVideos.delete(videoId)
             delete notifyVideoData[channelId].videos[videoId]
             continue
+          } else if (updateTime !== undefined && new Date(updateTime) < notifyVideoData[channelId].videos[videoId].updatedTime) {
+            notifyVideoData[channelId].videos[videoId].isUpdated = true
+          } else {
+            needGetStartTimeVideos.delete(videoId)
           }
 
           notifyVideoData[channelId].videos[videoId].startTime = startTime


### PR DESCRIPTION
配信済み、かつ、更新があった配信について、配信情報取得とそれに付随する処理を行おうとしてエラーになっているため、更新の有無によらず配信済みの配信については配信情報取得の対象から除外するようにします。

```
INFO	call youtubeApi.videos.list:  {
  part: [ 'liveStreamingDetails' ],
  id: [ '...' ],
  maxResults: 50
}
...
ERROR	Invoke Error 	{
    "errorType": "TypeError",
    "errorMessage": "Cannot set property 'startTime' of undefined",
    "stack": [
        "TypeError: Cannot set property 'startTime' of undefined",
        "    at Runtime.oCo [as handler] (/var/task/index.js:202:6361)",
        "    at runMicrotasks (<anonymous>)",
        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)"
    ]
}

```