### PR TITLE
Slackのコマンドをコピペで入力できるようにする

### DIFF
--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -56,7 +56,7 @@ async function getChannelData (
   message: GenericMessageEvent,
   say: SayFn
 ): Promise<RegisteredChannel | undefined> {
-  let id = message.text?.split(' ')[2]
+  let id = message.text?.split(/[  ]/)[2]
     .replace(/</g, '')
     .replace(/>/g, '')
     .replace(/https:\/\/www\.youtube\.com\/channel\//g, '')

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -56,7 +56,7 @@ async function getChannelData (
   message: GenericMessageEvent,
   say: SayFn
 ): Promise<RegisteredChannel | undefined> {
-  let id = message.text?.split(/[  ]/)[2]
+  let id = message.text?.split(/[  ]/)[2] // eslint-disable-line no-irregular-whitespace
     .replace(/</g, '')
     .replace(/>/g, '')
     .replace(/https:\/\/www\.youtube\.com\/channel\//g, '')


### PR DESCRIPTION
Slackのコマンドをコピペして入力した場合、スペースが https://unicode-table.com/jp/0020/ ではなく https://unicode-table.com/jp/00A0/ になる場合があるので、後者が含まれていても正常にコマンドを実行できるようにします。
