### PR TITLE
デプロイ用IAMロールにCDK用のssm parameterを取得する権限追加

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -19,7 +19,8 @@ import {
   aws_logs as logs,
   aws_secretsmanager as secretmanager,
   aws_s3 as s3,
-  aws_sns as sns
+  aws_sns as sns,
+  aws_ssm as ssm
 } from 'aws-cdk-lib'
 import { dynamoDBTableProps } from './props/dynamodb-table-props'
 import { rate } from './props/events-rule-props'
@@ -149,6 +150,11 @@ export class CdkStack extends Stack {
       new iam.ManagedPolicy(this, 'Policy-cdk', {
         managedPolicyName: 'youtube_streaming_watcher_cdk',
         statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['ssm:GetParameter'],
+            resources: [ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`).parameterArn]
+          }),
           new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
             actions: ['sts:AssumeRole'],


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/runs/5328771951?check_suite_focus=true

```
 ❌  Stack-youtube-streaming-watcher failed: Error: Stack-youtube-streaming-watcher: User: arn:aws:sts::***:assumed-role/youtube_streaming_watcher_cdk_deploy/GitHubActions is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:***:***:parameter/cdk-bootstrap/hnb659fds/version because no identity-based policy allows the ssm:GetParameter action
```

CDK用のssm parameterを取得できるようにデプロイ用IAMロールに権限を追加します。