### PR TITLE
youtube_streaming_watcher_notified_videosのReadCapacityUnits調整

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -152,11 +152,6 @@ export class CdkStack extends Stack {
         statements: [
           new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
-            actions: ['ssm:GetParameter'],
-            resources: [ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`).parameterArn]
-          }),
-          new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
             actions: ['sts:AssumeRole'],
             resources: ['lookup', 'deploy'].map(s =>
               iam.Role.fromRoleName(this, `Role-cdk_default_${s}`, `cdk-${qualifier}-${s}-role-${this.account}-${this.region}`).roleArn
@@ -335,5 +330,10 @@ export class CdkStack extends Stack {
         })
       ]
     }))
+    const cdkBootstrapParam = ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`)
+
+    for (const role of [cdkDiffRole, cdkDeployRole]) {
+      cdkBootstrapParam.grantRead(role)
+    }
   }
 }

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -220,6 +220,12 @@ export class CdkStack extends Stack {
       ),
       managedPolicies
     })
+    const cdkBootstrapParam = ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`)
+
+    for (const role of [cdkDiffRole, cdkDeployRole]) {
+      cdkBootstrapParam.grantRead(role)
+    }
+
     cdkDeployRole.addManagedPolicy(new iam.ManagedPolicy(this, 'Policy-cdk_deploy', {
       managedPolicyName: cdkDeployRoleName,
       statements: [
@@ -330,10 +336,5 @@ export class CdkStack extends Stack {
         })
       ]
     }))
-    const cdkBootstrapParam = ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`)
-
-    for (const role of [cdkDiffRole, cdkDeployRole]) {
-      cdkBootstrapParam.grantRead(role)
-    }
   }
 }

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -19,7 +19,8 @@ import {
   aws_logs as logs,
   aws_secretsmanager as secretmanager,
   aws_s3 as s3,
-  aws_sns as sns
+  aws_sns as sns,
+  aws_ssm as ssm
 } from 'aws-cdk-lib'
 import { dynamoDBTableProps } from './props/dynamodb-table-props'
 import { rate } from './props/events-rule-props'
@@ -149,6 +150,11 @@ export class CdkStack extends Stack {
       new iam.ManagedPolicy(this, 'Policy-cdk', {
         managedPolicyName: 'youtube_streaming_watcher_cdk',
         statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['ssm:GetParameter'],
+            resources: [ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`).parameterArn]
+          }),
           new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
             actions: ['sts:AssumeRole'],

--- a/lib/props/dynamodb-table-props.ts
+++ b/lib/props/dynamodb-table-props.ts
@@ -17,7 +17,7 @@ export const dynamoDBTableProps: dynamodb.TableProps[] = [
     tableName: 'youtube_streaming_watcher_notified_videos',
     partitionKey: { name: 'channel_id', type: dynamodb.AttributeType.STRING },
     sortKey: { name: 'video_id', type: dynamodb.AttributeType.STRING },
-    readCapacity: 4,
+    readCapacity: 3,
     writeCapacity: 1
   },
   {


### PR DESCRIPTION
`youtube_streaming_watcher_notified_videos` のReadCapacityUnitsを4で設定していますが、多すぎる感があるので3に減らします。
https://github.com/dev-hato/youtube_streaming_watcher/pull/147 を前提としているため、 https://github.com/dev-hato/youtube_streaming_watcher/pull/147 に向けています。