### PR TITLE
配信通知でRSSが404だった場合のエラー処理追加

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -80,7 +80,7 @@ export async function handler () {
         const feedParser = new Parser<{}, { id: string, updated: string }>({ customFields: { item: ['id', 'updated'] } })
         feed = await feedParser.parseURL(feedUrl)
       } catch (e: any) {
-        if (e.message !== 'Status code 404') {
+        if (e.message === 'Status code 404') {
           console.log('not found: ', feedUrl)
           continue
         } else {

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -72,10 +72,22 @@ export async function handler () {
     // 新着配信一覧取得
     for (let { channel_id: { S: channelId } } of channels) {
       channelId = channelId as string
-      const feedParser = new Parser<{}, { id: string, updated: string }>({ customFields: { item: ['id', 'updated'] } })
       const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
-      console.log('get feed: ', feedUrl)
-      const feed = await feedParser.parseURL(feedUrl)
+      let feed
+
+      try {
+        console.log('get feed: ', feedUrl)
+        const feedParser = new Parser<{}, { id: string, updated: string }>({ customFields: { item: ['id', 'updated'] } })
+        feed = await feedParser.parseURL(feedUrl)
+      } catch (e: any) {
+        if (e.message !== 'Status code 404') {
+          console.log('not found: ', feedUrl)
+          continue
+        } else {
+          throw e
+        }
+      }
+
       const videoIds = []
       const needGetStartTimeVideos: Set<string> = new Set()
       notifyVideoData[channelId] = { title: feed.title, videos: {} }


### PR DESCRIPTION
配信通知でRSSが404だった場合のエラー処理を追加します。
https://github.com/dev-hato/youtube_streaming_watcher/pull/147 を前提としているため、 https://github.com/dev-hato/youtube_streaming_watcher/pull/147 に向けています。

```
INFO	get feed:  https://www.youtube.com/feeds/videos.xml?channel_id=...
...
ERROR	Invoke Error 	{
    "errorType": "Error",
    "errorMessage": "Status code 404",
    "stack": [
        "Error: Status code 404",
        "    at ClientRequest.<anonymous> (/var/task/index.js:13:3005)",
        "    at Object.onceWrapper (events.js:520:26)",
        "    at ClientRequest.emit (events.js:400:28)",
        "    at HTTPParser.parserOnIncomingClient (_http_client.js:647:27)",
        "    at HTTPParser.parserOnHeadersComplete (_http_common.js:127:17)",
        "    at HTTPParser.execute (<anonymous>)",
        "    at TLSSocket.socketOnData (_http_client.js:515:22)",
        "    at TLSSocket.emit (events.js:400:28)",
        "    at addChunk (internal/streams/readable.js:293:12)",
        "    at readableAddChunk (internal/streams/readable.js:267:9)"
    ]
}
```