### PR TITLE
デプロイIAMロールへ必要な権限追加

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -220,6 +220,7 @@ export class CdkStack extends Stack {
       ),
       managedPolicies
     })
+    iam.Role.fromRoleName(this, 'Role-cdk_default_file_publishing_role', `cdk-${qualifier}-file-publishing-role-${this.account}-${this.region}`).grant(cdkDeployRole, 'sts:AssumeRole')
     const cdkBootstrapParam = ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`)
 
     for (const role of [cdkDiffRole, cdkDeployRole]) {


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/runs/5347231606?check_suite_focus=true

```
current credentials could not be used to assume 'arn:aws:iam::***:role/cdk-hnb659fds-file-publishing-role-***-***', but are for the right account. Proceeding anyway.
...
[100%] fail: Access Denied

 ❌  Stack-youtube-streaming-watcher failed: Error: Failed to publish one or more assets. See the error messages above for more information.
```

上記を成功させるため、権限を追加します。