### PR TITLE
チャンネル追加時のエラー処理修正

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -220,6 +220,7 @@ export class CdkStack extends Stack {
       ),
       managedPolicies
     })
+    iam.Role.fromRoleName(this, 'Role-cdk_default_file_publishing_role', `cdk-${qualifier}-file-publishing-role-${this.account}-${this.region}`).grant(cdkDeployRole, 'sts:AssumeRole')
     const cdkBootstrapParam = ssm.StringParameter.fromStringParameterName(this, 'SSMParameter-cdk_bootstrap', `/cdk-bootstrap/${qualifier}/version`)
 
     for (const role of [cdkDiffRole, cdkDeployRole]) {

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -99,6 +99,12 @@ async function getChannelData (
           say
         )
         return
+      } else if (e.message === 'Status code 500') {
+        await postMessage(
+          'チャンネルが存在するかの確認中にエラーが発生しました',
+          say
+        )
+        return
       } else {
         throw e
       }


### PR DESCRIPTION
RSS取得時に500を返すケースがあるので、その際のエラー処理を追加します。
https://github.com/dev-hato/youtube_streaming_watcher/pull/162 を前提としているため、 https://github.com/dev-hato/youtube_streaming_watcher/pull/162 に向けています。