### PR TITLE
system manager parameter storeでSecureStringを使えるよう修正

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -61,7 +61,7 @@ export class CdkStack extends Stack {
       ),
       youtubeApiKey: ssm.StringParameter.fromSecureStringParameterAttributes(
         this,
-        'Secret-youtube',
+        'Secret-youtube_api_key',
         {
           parameterName: '/youtube_streaming_watcher_youtube/youtube_api_key'
         }

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -30,20 +30,24 @@ export class CdkStack extends Stack {
     super(scope, id, props)
 
     const secrets: { [secretName: string]: ssm.IStringParameter } = {
-      slackBotToken: ssm.StringParameter.fromStringParameterName(
+      slackBotToken: ssm.StringParameter.fromSecureStringParameterAttributes(
         this,
         'Secret-slack_bot_token',
-        '/youtube_streaming_watcher_slack/slack_bot_token'
+        {
+          parameterName: '/youtube_streaming_watcher_slack/slack_bot_token'
+        }
       ),
       slackChannel: ssm.StringParameter.fromStringParameterName(
         this,
         'Secret-slack_channel',
         '/youtube_streaming_watcher_slack/slack_channel'
       ),
-      slackSigningSecret: ssm.StringParameter.fromStringParameterName(
+      slackSigningSecret: ssm.StringParameter.fromSecureStringParameterAttributes(
         this,
         'Secret-slack_signing_secret',
-        '/youtube_streaming_watcher_slack/slack_signing_secret'
+        {
+          parameterName: '/youtube_streaming_watcher_slack/slack_signing_secret'
+        }
       ),
       slackAlertWorkspaceId: ssm.StringParameter.fromStringParameterName(
         this,
@@ -55,10 +59,12 @@ export class CdkStack extends Stack {
         'Secret-slack_alert_channel_id',
         '/youtube_streaming_watcher_slack_alert/channel_id'
       ),
-      youtubeApiKey: ssm.StringParameter.fromStringParameterName(
+      youtubeApiKey: ssm.StringParameter.fromSecureStringParameterAttributes(
         this,
         'Secret-youtube',
-        '/youtube_streaming_watcher_youtube/youtube_api_key'
+        {
+          parameterName: '/youtube_streaming_watcher_youtube/youtube_api_key'
+        }
       )
     }
     const environment = {


### PR DESCRIPTION
以下のSecretをSecureStringとして読み込むように修正します。
* `/youtube_streaming_watcher_slack/slack_bot_token`
* `/youtube_streaming_watcher_slack/slack_signing_secret`
* `/youtube_streaming_watcher_youtube/youtube_api_key`