### PR TITLE
Secret管理をSecret Managerに戻す

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -30,24 +30,20 @@ export class CdkStack extends Stack {
     super(scope, id, props)
 
     const secrets: { [secretName: string]: ssm.IStringParameter } = {
-      slackBotToken: ssm.StringParameter.fromSecureStringParameterAttributes(
+      slackBotToken: ssm.StringParameter.fromStringParameterName(
         this,
         'Secret-slack_bot_token',
-        {
-          parameterName: '/youtube_streaming_watcher_slack/slack_bot_token'
-        }
+        '/youtube_streaming_watcher_slack/slack_bot_token'
       ),
       slackChannel: ssm.StringParameter.fromStringParameterName(
         this,
         'Secret-slack_channel',
         '/youtube_streaming_watcher_slack/slack_channel'
       ),
-      slackSigningSecret: ssm.StringParameter.fromSecureStringParameterAttributes(
+      slackSigningSecret: ssm.StringParameter.fromStringParameterName(
         this,
         'Secret-slack_signing_secret',
-        {
-          parameterName: '/youtube_streaming_watcher_slack/slack_signing_secret'
-        }
+        '/youtube_streaming_watcher_slack/slack_signing_secret'
       ),
       slackAlertWorkspaceId: ssm.StringParameter.fromStringParameterName(
         this,
@@ -59,12 +55,10 @@ export class CdkStack extends Stack {
         'Secret-slack_alert_channel_id',
         '/youtube_streaming_watcher_slack_alert/channel_id'
       ),
-      youtubeApiKey: ssm.StringParameter.fromSecureStringParameterAttributes(
+      youtubeApiKey: ssm.StringParameter.fromStringParameterName(
         this,
-        'Secret-youtube_api_key',
-        {
-          parameterName: '/youtube_streaming_watcher_youtube/youtube_api_key'
-        }
+        'Secret-youtube',
+        '/youtube_streaming_watcher_youtube/youtube_api_key'
       )
     }
     const environment = {


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/pull/160, https://github.com/dev-hato/youtube_streaming_watcher/pull/171 をRevertします。

https://github.com/dev-hato/youtube_streaming_watcher/runs/5352882383?check_suite_focus=true
> ❌  Stack-youtube-streaming-watcher failed: Error [ValidationError]: Incorrect format is used in the following SSM reference: [{{resolve:ssm-secure:/youtube_streaming_watcher_youtube/youtube_api_key:}},{{resolve:ssm-secure:/youtube_streaming_watcher_slack/slack_signing_secret:}},{{resolve:ssm-secure:/youtube_streaming_watcher_slack/slack_bot_token:}}]

https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-ssm-secure-strings
>バージョン
>使用するパラメータのバージョンを指定する整数。正確なバージョンを指定する必要があります。現在、AWS CloudFormation が最新バージョンのパラメータを使用するように指定することはできません。

SecretStringについてはバージョン指定が必須であり、Secretを書き換えるたびにコード内のバージョンを書き換える必要があるようです。
しかし、Secret差し替えのたびにコードの書き換えが生じるのも望ましくないように感じるので、system managerのparameter storeを使うのをやめることにします。