### PR TITLE
Revert "CDKでのリソース削除時にテーブルを残すようにする"

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -189,7 +189,7 @@ export class CdkStack extends Stack {
 
     for (const tableProp of dynamoDBTableProps) {
       const table = new dynamodb.Table(this, `DynamoDBTable-${tableProp.tableName}`, Object.assign(tableProp, {
-        removalPolicy: RemovalPolicy.RETAIN
+        removalPolicy: RemovalPolicy.DESTROY
       }))
 
       for (const func of functions) {


### PR DESCRIPTION
dev-hato/youtube_streaming_watcher#174 がうまくCDKでデプロイされていないようなので、一旦Revertします。