### PR TITLE
forkしたリポジトリでもうまく動作するようにする・リポジトリ名を変数から取得するようにする

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    if: github.repository == 'dev-hato/hato-atama' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
+    if: github.repository == 'dev-hato/youtube_streaming_watcher' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    if: github.repository == 'dev-hato/youtube_streaming_watcher' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    if: github.repository == 'dev-hato/hato-atama' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -16,6 +16,7 @@ jobs:
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"
           ROLE+=":role/youtube_streaming_watcher_cdk_deploy"
           echo "ROLE=${ROLE}" >> "${GITHUB_ENV}"
+          echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
           role-to-assume: ${{ env.ROLE }}

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -10,8 +10,13 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
-    if: github.repository == 'dev-hato/youtube_streaming_watcher' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
     steps:
+      - if: github.repository == 'dev-hato/youtube_streaming_watcher'
+        run: echo "${{github.repository}}"
+      - if: secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != ''
+        run: echo "B"
+      - if: github.repository == 'dev-hato/youtube_streaming_watcher' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
+        run: echo "C"
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"
           ROLE+=":role/youtube_streaming_watcher_cdk_diff"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
+    if: github.repository == 'dev-hato/hato-atama' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - if: github.repository == 'dev-hato/youtube_streaming_watcher'
         run: echo "${{github.repository}}"
-      - if: secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != ''
+      - if: ${{secrets.AWS_ACCOUNT}} != '' && ${{secrets.AWS_REGION}} != ''
         run: echo "B"
-      - if: github.repository == 'dev-hato/youtube_streaming_watcher' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
+      - if: github.repository == 'dev-hato/youtube_streaming_watcher' || (${{secrets.AWS_ACCOUNT}} != '' && ${{secrets.AWS_REGION}} != '')
         run: echo "C"
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
-    if: github.repository == 'dev-hato/hato-atama' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
+    if: github.repository == 'dev-hato/youtube_streaming_watcher' || (secrets.AWS_ACCOUNT != '' && secrets.AWS_REGION != '')
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -15,6 +15,7 @@ jobs:
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"
           ROLE+=":role/youtube_streaming_watcher_cdk_diff"
           echo "ROLE=${ROLE}" >> "${GITHUB_ENV}"
+          echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
           role-to-assume: ${{ env.ROLE }}

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
+    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -11,12 +11,6 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - if: github.repository == 'dev-hato/youtube_streaming_watcher'
-        run: echo "${{github.repository}}"
-      - if: ${{secrets.AWS_ACCOUNT}} != '' && ${{secrets.AWS_REGION}} != ''
-        run: echo "B"
-      - if: github.repository == 'dev-hato/youtube_streaming_watcher' || (${{secrets.AWS_ACCOUNT}} != '' && ${{secrets.AWS_REGION}} != '')
-        run: echo "C"
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"
           ROLE+=":role/youtube_streaming_watcher_cdk_diff"

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -32,6 +32,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
+      - run: echo "REPOSITORY=${{github.repository}}" >> "$GITHUB_ENV"
       - run: mv .env.example .env
       - run: docker compose build --build-arg BUILDKIT_INLINE_CACHE=1
       - run: docker compose push

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -15,6 +15,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     permissions:
       packages: write
+    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - name: Login to GitHub Container Registry

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -61,7 +61,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            let head = "dev-hato:fix-format-"
+            let head = process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-format-"
             head += HEAD_REF
             const pulls_list_params = {
               owner: context.repo.owner,
@@ -87,7 +87,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            let head = "dev-hato:fix-format-"
+            let head = process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-format-"
             head += HEAD_REF
             const number = "#${{github.event.pull_request.number}}"
             let title = "format修正 "
@@ -141,7 +141,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -50,6 +50,14 @@ jobs:
           GITHUB_HEAD="HEAD:refs/heads/fix-format-"
           GITHUB_HEAD+="${HEAD_REF}"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         env:
@@ -61,7 +69,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            let head = process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-format-"
+            let head = "${{steps.set_org_name.outputs.result}}:fix-format-"
             head += HEAD_REF
             const pulls_list_params = {
               owner: context.repo.owner,
@@ -87,7 +95,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            let head = process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-format-"
+            let head = "${{steps.set_org_name.outputs.result}}:fix-format-"
             head += HEAD_REF
             const number = "#${{github.event.pull_request.number}}"
             let title = "format修正 "
@@ -141,7 +149,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -69,6 +69,14 @@ jobs:
           REPO_URL+="${{github.repository}}.git"
           GITHUB_HEAD="HEAD:refs/heads/fix-version-${HEAD_REF}"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         env:
@@ -83,7 +91,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-" + HEAD_REF,
               base: HEAD_REF,
               state: "open"
             }
@@ -110,7 +118,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-" + HEAD_REF,
               base: HEAD_REF,
               title,
               body: number + " のnodeをアップデートします。"
@@ -155,7 +163,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -83,7 +83,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-" + HEAD_REF,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-" + HEAD_REF,
               base: HEAD_REF,
               state: "open"
             }
@@ -110,7 +110,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-" + HEAD_REF,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-" + HEAD_REF,
               base: HEAD_REF,
               title,
               body: number + " のnodeをアップデートします。"
@@ -155,7 +155,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/update_pre_commit_config.yml
+++ b/.github/workflows/update_pre_commit_config.yml
@@ -98,7 +98,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-pre-commit-config-" + HEAD_REF,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-pre-commit-config-" + HEAD_REF,
               base: HEAD_REF,
               state: "open"
             }
@@ -125,7 +125,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-pre-commit-config-" + HEAD_REF,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-pre-commit-config-" + HEAD_REF,
               base: HEAD_REF,
               title,
               body: number + " のgitleaksをアップデートします。"
@@ -170,7 +170,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/update_pre_commit_config.yml
+++ b/.github/workflows/update_pre_commit_config.yml
@@ -84,6 +84,14 @@ jobs:
           REPO_URL+="${{github.repository}}.git"
           GITHUB_HEAD="HEAD:refs/heads/fix-version-pre-commit-config-${HEAD_REF}"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         env:
@@ -98,7 +106,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-pre-commit-config-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-pre-commit-config-" + HEAD_REF,
               base: HEAD_REF,
               state: "open"
             }
@@ -125,7 +133,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":fix-version-pre-commit-config-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-pre-commit-config-" + HEAD_REF,
               base: HEAD_REF,
               title,
               body: number + " のgitleaksをアップデートします。"
@@ -170,7 +178,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: process.env.GITHUB_REPOSITORY.split('/')[0] + ":" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
     * `youtube_streaming_watcher_youtube`: 配信通知関連 (YouTube)
         * `youtube_api_key`: YouTube Data API用のAPIキー
 5. スタックをデプロイします。  
-なお、リポジトリが `dev-hato/youtube_streaming_watcher` 以外の場合は環境変数 `REPOSITORY=org/repository"` をセットした状態で実行します。
+なお、リポジトリが `dev-hato/youtube_streaming_watcher` 以外の場合は環境変数 `REPOSITORY=org/repository` をセットした状態で実行します。
 
    ```sh
    cdk deploy

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
         * `channel_id`: 通知先のチャンネルID
     * `youtube_streaming_watcher_youtube`: 配信通知関連 (YouTube)
         * `youtube_api_key`: YouTube Data API用のAPIキー
-5. スタックをデプロイします。
+5. スタックをデプロイします。  
+なお、リポジトリが `dev-hato/youtube_streaming_watcher` 以外の場合は環境変数 `REPOSITORY=org/repository"` をセットした状態で実行します。
 
    ```sh
    cdk deploy

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Slack上でbotに対してリプライを送ることで、設定を変更でき
    TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g" | sed -e "s/^main$/latest/g") docker compose up
    ```
 
+### forkしたリポジトリでCI/CDを動かす方法
+
+以下のRepository secretsを設定します。
+
+* `AWS_ACCOUNT`: AWSアカウントID
+* `AWS_REGION`: AWSのリージョン
+
 ## 仕様
 
 ### Node.jsのバージョン

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       context: .
       target: notify
       cache_from:
-        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
-        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notifyy:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notifyy
       args:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - DYNAMODB_ENDPOINT
         - DYNAMODB_REGION
-    image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
+    image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notifyy:${TAG_NAME}
     env_file: .env
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       context: .
       target: notify
       cache_from:
-        - ghcr.io/dev-hato/youtube_streaming_watcher/notify:${TAG_NAME}
-        - ghcr.io/dev-hato/youtube_streaming_watcher/notify
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify
       args:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - DYNAMODB_ENDPOINT
         - DYNAMODB_REGION
-    image: ghcr.io/dev-hato/youtube_streaming_watcher/notify:${TAG_NAME}
+    image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
     env_file: .env
     depends_on:
       - db
@@ -23,14 +23,14 @@ services:
       context: .
       target: reply
       cache_from:
-        - ghcr.io/dev-hato/youtube_streaming_watcher/reply:${TAG_NAME}
-        - ghcr.io/dev-hato/youtube_streaming_watcher/reply
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply
       args:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - DYNAMODB_ENDPOINT
         - DYNAMODB_REGION
-    image: ghcr.io/dev-hato/youtube_streaming_watcher/reply:${TAG_NAME}
+    image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply:${TAG_NAME}
     env_file: .env
     ports:
       - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       context: .
       target: notify
       cache_from:
-        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notifyy:${TAG_NAME}
-        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notifyy
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify
       args:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - DYNAMODB_ENDPOINT
         - DYNAMODB_REGION
-    image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notifyy:${TAG_NAME}
+    image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
     env_file: .env
     depends_on:
       - db

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -142,7 +142,7 @@ export class CdkStack extends Stack {
           provider.openIdConnectProviderArn,
           {
             StringEquals: {
-              'token.actions.githubusercontent.com:sub': 'repo:dev-hato/youtube_streaming_watcher:' + d.oidcSub,
+              'token.actions.githubusercontent.com:sub': 'repo:' + (process.env.REPOSITORY || 'dev-hato/youtube_streaming_watcher') + ':' + d.oidcSub,
               'token.actions.githubusercontent.com:aud': oidcAud
             }
           },


### PR DESCRIPTION
forkしたリポジトリ上でPRを立てた場合やforkしたリポジトリから本リポジトリへPRを出した場合にうまく動作するようにします。
forkしたリポジトリから本リポジトリへPRを出した場合はdockerイメージのpushとインフラの差分の表示をskipします。

また、リポジトリ名をできるだけ変数から取得するようにします。