### PR TITLE
sleepにawait追加

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -104,7 +104,7 @@ export async function handler () {
           }
 
           console.error(e)
-          sleep(1000)
+          await sleep(1000)
         }
       }
 


### PR DESCRIPTION
`sleep` 関数はPromiseを返しますが、 `await` をつけていなかったのでつけます。