### PR TITLE
動画投稿から1日以上経っている場合は新着通知しない

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -374,6 +374,8 @@ export async function handler () {
 
             const updatedTime = notifyVideoData[channelId].videos[videoId].updatedTime.toISOString()
             const now = new Date()
+            const yesterday = new Date(now.getTime())
+            yesterday.setDate(now.getDate() - 1)
 
             if (notifyVideoData[channelId].videos[videoId].needInsert === true) { // データがない場合はINSERTする
               await runQuery(
@@ -387,8 +389,11 @@ export async function handler () {
               )
             }
 
-            // 既に配信開始している場合は通知しない
-            if (notifyVideoData[channelId].videos[videoId].isLiveStreaming && startTime < now) {
+            // 既に配信開始している、もしくは、動画投稿から1日以上経っている場合は通知しない
+            if (
+              (notifyVideoData[channelId].videos[videoId].isLiveStreaming && startTime < now) ||
+              (!notifyVideoData[channelId].videos[videoId].isLiveStreaming && startTime < yesterday)
+            ) {
               console.log(`start time has passed: channel_id ${channelId}, video_id: ${videoId}, start_time: ${startTime}`)
               delete notifyVideoData[channelId].videos[videoId]
             }


### PR DESCRIPTION
配信者が動画や配信を限定公開にした結果、古い動画がRSSの通知対象に挙がり、新着通知されるケースがあるので、動画投稿から1日以上経っている場合は新着通知しないようにします。