### PR TITLE
一回あたりのツイート取得数を10ツイートにする

### DIFF
--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -165,7 +165,7 @@ export async function handler () {
       if (twitterId !== undefined) {
         await sleep(1000)
         console.log('get twitter user timeline:', twitterId)
-        const timeLine = await twitterApiReadOnly.v2.userTimeline(twitterId, { max_results: 30 })
+        const timeLine = await twitterApiReadOnly.v2.userTimeline(twitterId, { max_results: 10 })
         const tweetDataList: Array<{ url: string, createdAt: string | undefined }> = []
         let tweets: TweetV2[] = timeLine.tweets
 


### PR DESCRIPTION
Lambda関数 (配信通知) の実行に10分以上かかるようなので、一回あたりのツイート取得数を10ツイートにします。