### PR TITLE
npm installの代わりにnpm ci --prefer-offlineを使う

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -30,5 +30,5 @@ jobs:
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
           npm install -g "npm@${npm_version}"
-          npm install
+          npm ci --prefer-offline
       - run: npx cdk deploy --require-approval never

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -30,7 +30,7 @@ jobs:
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
           npm install -g "npm@${npm_version}"
-          npm install
+          npm ci --prefer-offline
       # 差分があったときは差分を出力する
       - name: Show diff
         id: diff

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
           npm install -g "npm@${npm_version}"
-          npm install
+          npm ci --prefer-offline
       - run: npm run fix
       # 差分があったときは差分を出力する
       - name: Show diff

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,7 +52,7 @@ jobs:
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
           npm install -g "npm@${npm_version}"
-          npm install
+          npm ci --prefer-offline
 
       ################################
       # Run Linter against code base #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.8.1
+    rev: v8.8.2
     hooks:
       - id: gitleaks


### PR DESCRIPTION
`npm install` の代わりに `npm ci --prefer-offline` を使うことでCIの実行時間を短縮してみます。
* `npm ci`: `package-lock.json` (≠ `package.json` ) を元にインストールする
* `--prefer-offline`: ローカルキャッシュがある場合はそれを使ってインストールする, そうでない場合はサーバーからダウンロードする