### PR TITLE
Dockerイメージビルド時にpullする

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -41,4 +41,5 @@ jobs:
         uses: docker/bake-action@v1.7.0
         with:
           push: true
+          pull: true
           files: docker-compose.yml


### PR DESCRIPTION
Dockerイメージビルド時にpullするとキャッシュが効きそうなので、pullするようにしてみます。