### PR TITLE
Dockerfile内でnpm ciを使う

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY .npmignore .
 COPY .npmrc .
 COPY package*.json .
 RUN npm install -g npm@8.5.1 \
-    && npm install
+    && npm ci
 COPY tsconfig.json .
 COPY lib/props/ lib/props/
 COPY src/common/ src/common/


### PR DESCRIPTION
Dockerfile内で `npm install` の代わりに `npm ci` を使うことで、開発環境とのパッケージの差を無くします。