### PR TITLE
Dockerのビルド時間改善

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -38,14 +38,18 @@ jobs:
         if: ${{ github.event_name == 'push' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "$GITHUB_ENV"
       - run: mv .env.example .env
-      - name: Build and push
+      - name: Build and push (build)
         uses: docker/bake-action@v2.0.0
         with:
           push: true
-          pull: true
-          files: |
-              build.docker-compose.yml
-              docker-compose.yml
+          files: build.docker-compose.yml
+      - name: Build and push (main)
+        uses: docker/bake-action@v2.0.0
+        env:
+          DOCKER_CONTENT_TRUST: 1
+        with:
+          push: true
+          files: docker-compose.yml
 
   update-version:
     runs-on: ubuntu-latest

--- a/build.docker-compose.yml
+++ b/build.docker-compose.yml
@@ -8,6 +8,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/build:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/build
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         platforms:
           - linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,10 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/build:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/build
       args:
-        - AWS_ACCESS_KEY_ID
-        - AWS_SECRET_ACCESS_KEY
-        - DYNAMODB_ENDPOINT
-        - DYNAMODB_REGION
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         platforms:
           - linux/amd64
@@ -29,11 +28,10 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/build:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/build
       args:
-        - AWS_ACCESS_KEY_ID
-        - AWS_SECRET_ACCESS_KEY
-        - DYNAMODB_ENDPOINT
-        - DYNAMODB_REGION
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         platforms:
           - linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       target: notify
+      # jscpd:ignore-start
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify
@@ -16,6 +17,7 @@ services:
         platforms:
           - linux/amd64
           - linux/arm64
+    # jscpd:ignore-end
     image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/notify:${TAG_NAME}
     env_file: .env
     depends_on:
@@ -25,6 +27,7 @@ services:
     build:
       context: .
       target: reply
+      # jscpd:ignore-start
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply
@@ -36,6 +39,7 @@ services:
         platforms:
           - linux/amd64
           - linux/arm64
+    # jscpd:ignore-end
     image: ghcr.io/${REPOSITORY:-dev-hato/youtube_streaming_watcher}/reply:${TAG_NAME}
     env_file: .env
     ports:


### PR DESCRIPTION
Dockerイメージのビルドに時間がかかりすぎているので修正します。
* 本イメージのビルド時にビルド用のイメージをキャッシュとして使うようにする
* 常に最新のイメージをpullすると時間がかかりそうなので `pull: true` 削除
* `BUILDKIT_INLINE_CACHE=1` 設定