### PR TITLE
Buildxのセットアップ時にDOCKER_CONTENT_TRUST=1をセットしないようにする

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        env:
-          DOCKER_CONTENT_TRUST: 1
       # jscpd:ignore-start
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/runs/6656002530?check_suite_focus=true#step:5:137

```
  Warning: docker: Error: remote trust data does not exist for docker.io/moby/buildkit: notary.docker.io does not have trust data for docker.io/moby/buildkit.
  See 'docker run --help'.
```

上記のWarningを解消するため、Buildxのセットアップ時に `DOCKER_CONTENT_TRUST=1` をセットしないようにします。