### PR TITLE
renovateで@types系のパッケージのアップデートを扱えるようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,21 @@
   "extends": [
     "config:base",
     "group:linters",
-    "group:definitelyTyped",
     ":timezone(Asia/Tokyo)"
+  ],
+  "packageRules": [
+    {
+      "groupName": "definitelyTyped",
+      "matchPackagePrefixes": [
+        "@types/"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "patch",
+        "minor",
+        "major"
+      ]
+    }
   ],
   "automerge": true,
   "platformAutomerge": true


### PR DESCRIPTION
`matchUpdateTypes` を明示的に指定することで、renovateで@types系のパッケージのアップデートを扱えるようにします。