### PR TITLE
チャンネルにTwitterアカウントが設定されていない場合の処理修正

### DIFF
--- a/src/common/youtube.ts
+++ b/src/common/youtube.ts
@@ -9,7 +9,7 @@ export async function getTwitterUserName (youtubeChannelId: string): Promise<str
 
   for (const pattern of [/twitter.com%2F(\w{1,50})"/, /twitter.com\/(\w{1,50})/]) {
     const userNames = response.data.match(pattern)
-    if (userNames !== null && 1 < userNames.length) {
+    if (userNames !== null && userNames.length > 1) {
       return userNames[1]
     }
   }

--- a/src/common/youtube.ts
+++ b/src/common/youtube.ts
@@ -6,11 +6,13 @@ export async function getTwitterUserName (youtubeChannelId: string): Promise<str
   const url = `https://www.youtube.com/channel/${youtubeChannelId}/about`
   console.log('get:', url)
   const response = await axios.get(url)
-  const userNames = response.data.match(/twitter.com%2F([^"]*)"/)
 
-  if (userNames === null || userNames.length < 2) {
-    throw new Error(`Twitter ID can not be found on YouTube about page: ${youtubeChannelId}`)
+  for (const pattern of [/twitter.com%2F(\w{1,50})"/, /twitter.com\/(\w{1,50})/]) {
+    const userNames = response.data.match(pattern)
+    if (userNames !== null && 1 < userNames.length) {
+      return userNames[1]
+    }
   }
 
-  return userNames[1]
+  throw new Error(`Twitter ID can not be found on YouTube about page: ${youtubeChannelId}`)
 }

--- a/src/common/youtube.ts
+++ b/src/common/youtube.ts
@@ -8,7 +8,7 @@ export async function getTwitterUserName (youtubeChannelId: string): Promise<str
   const response = await axios.get(url)
   const userNames = response.data.match(/twitter.com%2F([^"]*)"/)
 
-  if (userNames.length < 2) {
+  if (userNames === null || userNames.length < 2) {
     throw new Error(`Twitter ID can not be found on YouTube about page: ${youtubeChannelId}`)
   }
 


### PR DESCRIPTION
YoutubeチャンネルにTwitterアカウントが設定されていない場合は概要欄のテキストからTwitter IDを取得するようにします。
また、それでもTwitterアカウントを取得できなかった場合に正規表現のマッチ結果の取得でエラーにならないようにします。