### PR TITLE
npm install -gのコマンド修正

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -29,6 +29,6 @@ jobs:
       - run: |
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
-          npm install --prefer-offline -g "npm@${npm_version}"
+          npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       - run: npx cdk deploy --require-approval never

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -29,7 +29,7 @@ jobs:
       - run: |
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
-          npm install --prefer-offline -g "npm@${npm_version}"
+          npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       # 差分があったときは差分を出力する
       - name: Show diff

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -120,7 +120,7 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: |
           DEPENDABOT_NPM_VERSION="${{steps.get_dependabot_node_version.outputs.npm_version}}"
-          npm install --prefer-offline -g "npm@${DEPENDABOT_NPM_VERSION}"
+          npm install --prefer-offline --location=global "npm@${DEPENDABOT_NPM_VERSION}"
           npm install
       # 差分があったときは差分を出力する
       - name: Show diff

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
       - run: |
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
-          npm install --prefer-offline -g "npm@${npm_version}"
+          npm install --prefer-offline --location=global "npm@${npm_version}"
           npm install
       - run: npm run fix
       # 差分があったときは差分を出力する

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -20,6 +20,6 @@ jobs:
       - run: |
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
-          npm install --prefer-offline -g "npm@${npm_version}"
+          npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       - run: npx renovate-config-validator

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -51,7 +51,7 @@ jobs:
       - run: |
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
-          npm install --prefer-offline -g "npm@${npm_version}"
+          npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
 
       ################################

--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
-          npm install --prefer-offline -g "npm@${npm_version}"
+          npm install --prefer-offline --location=global "npm@${npm_version}"
           npm install --prefer-offline js-yaml
       - name: Update .gitleaks.toml
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14.19.3-bullseye-slim AS base
 RUN apt-get update \
     # hadolint ignore=DL3008
     && apt-get install -y --no-install-recommends curl \
-    && npm install -g npm@8.5.1 \
+    && npm install --location=global npm@8.5.1 \
     && find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
     && find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; \
     && rm -rf /root/.npm /tmp /var/lib/apt/lists


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/runs/6922221889?check_suite_focus=true

```
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
```

とのことなので、 `npm install -g` の代わりに `npm install --location=global` を使うようにします。