### PR TITLE
CI update-major-node を定時実行にする

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -35,7 +35,6 @@ jobs:
 
             for (const head_name of ["fix-format-" + HEAD_REF,
                                      "fix-version-" + HEAD_REF,
-                                     "update-major-node-" + HEAD_REF,
                                      "fix-version-pre-commit-config-" + HEAD_REF]) {
               let head = "${{github.event.pull_request.head.repo.owner.login}}:"
               head += head_name

--- a/.github/workflows/update-major-node.yml
+++ b/.github/workflows/update-major-node.yml
@@ -3,7 +3,7 @@ name: update-major-node
 
 on:
   schedule:
-    - '* 21 * * *' # 06:00 JST
+    - cron: '* 21 * * *' # 06:00 JST
 
 jobs:
   # AWS Lambdaのランタイムのページをスクレイピングし、そこに記述されているNode.jsランタイムのバージョンがアップデートされていたらDockerイメージをアップデートする

--- a/.github/workflows/update-major-node.yml
+++ b/.github/workflows/update-major-node.yml
@@ -2,7 +2,8 @@
 name: update-major-node
 
 on:
-  pull_request:
+  schedule:
+    - '* 21 * * *' # 06:00 JST
 
 jobs:
   # AWS Lambdaのランタイムのページをスクレイピングし、そこに記述されているNode.jsランタイムのバージョンがアップデートされていたらDockerイメージをアップデートする
@@ -15,7 +16,6 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3.3.0
         with:
           node-version-file: .node-version
@@ -66,12 +66,10 @@ jobs:
           result=$(git diff)
           echo "::set-output name=result::$result"
       - run: |
-          REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
+          REPO_NAME="dev-hato/youtube_streaming_watcher"
           echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
       # 差分があったときは、コミットを作りpushする
       - name: Push
-        env:
-          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != '' }}
         run: |
@@ -83,7 +81,7 @@ jobs:
           REPO_URL="https://"
           REPO_URL+="${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/"
           REPO_URL+="${{github.repository}}.git"
-          GITHUB_HEAD="HEAD:refs/heads/update-major-node-${HEAD_REF}"
+          GITHUB_HEAD="HEAD:refs/heads/update-major-node"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
       - name: Set org name
         uses: actions/github-script@v6.1.0
@@ -95,8 +93,6 @@ jobs:
           script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6.1.0
-        env:
-          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != '' }}
         id: get_pull_requests
@@ -107,7 +103,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "${{steps.set_org_name.outputs.result}}:update-major-node-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:update-major-node",
               base: HEAD_REF,
               state: "open"
             }
@@ -118,8 +114,6 @@ jobs:
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v6.1.0
-        env:
-          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
           && steps.get_pull_requests.outputs.result == 0 }}
@@ -128,53 +122,30 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            const number = "#${{github.event.pull_request.number}}"
-            let title = "nodeメジャーアップデート "
-            title += number
+            let title = "nodeメジャーアップデート"
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "${{steps.set_org_name.outputs.result}}:update-major-node-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:update-major-node",
               base: HEAD_REF,
               title,
-              body: number + " のnodeをメジャーアップデートします。"
+              body: "nodeをメジャーアップデートします。"
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = await github.rest.pulls.create(
                                       pulls_create_params
                                     )
             return create_pull_res.data.number
-      - name: Assign a user
-        uses: actions/github-script@v6.1.0
-        if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != ''
-          && steps.get_pull_requests.outputs.result == 0
-          && github.event.pull_request.user.login != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'renovate[bot]' }}
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const issues_add_assignees_params = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{steps.create_pull_request.outputs.result}},
-              assignees: ["${{github.event.pull_request.user.login}}"]
-            }
-            console.log("call issues.addAssignees:")
-            console.log(issues_add_assignees_params)
-            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にPRがある状態で、手動でを正した場合、PRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v6.1.0
-        env:
-          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result == '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            const head_name = "update-major-node-" + HEAD_REF
+            const head_name = "update-major-node"
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo

--- a/.github/workflows/update-major-node.yml
+++ b/.github/workflows/update-major-node.yml
@@ -3,7 +3,7 @@ name: update-major-node
 
 on:
   schedule:
-    - cron: '* 21 * * *' # 06:00 JST
+    - cron: '0 21 * * *' # 06:00 JST
 
 jobs:
   # AWS Lambdaのランタイムのページをスクレイピングし、そこに記述されているNode.jsランタイムのバージョンがアップデートされていたらDockerイメージをアップデートする


### PR DESCRIPTION
AWSのページを無秩序にクロールするのはやはり行儀が悪いので、CI `update-major-node` を1日1回 (06:00 JST) 定時実行する形式に変更します。