### PR TITLE
youtube_streaming_watcher_tweet_videosのリードキャパシティを2にする

### DIFF
--- a/lib/props/dynamodb-table-props.ts
+++ b/lib/props/dynamodb-table-props.ts
@@ -44,7 +44,7 @@ export const dynamoDBTableProps: dynamodb.TableProps[] = [
     tableName: 'youtube_streaming_watcher_tweet_videos',
     partitionKey: { name: 'tweet_id', type: dynamodb.AttributeType.STRING },
     sortKey: { name: 'video_id', type: dynamodb.AttributeType.STRING },
-    readCapacity: 1,
+    readCapacity: 2,
     writeCapacity: 1
   }
 ]


### PR DESCRIPTION
```
ERROR	ProvisionedThroughputExceededException: The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
    at y0 (/var/task/index.js:103:112722)
    at FTo (/var/task/index.js:103:85164)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /var/task/index.js:97:6696120
    at async /var/task/index.js:114:4094
    at async Cge.retry (/var/task/index.js:103:285321)
    at async /var/task/index.js:103:266595
    at async jm (/var/task/index.js:259:12246)
    at async Runtime.L$r [as handler] (/var/task/index.js:269:2173) {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: '***',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 3,
    totalRetryDelay: 1060
  },
  __type: 'com.amazonaws.dynamodb.v20120810#ProvisionedThroughputExceededException'
}
```

`youtube_streaming_watcher_tweet_videos` の読み込みの上限を超えているようなのでリードキャパシティを2に上げます。