### PR TITLE
renovateのextendの順序変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "github>dev-hato/renovate-config",
-    "config:base"
+    "config:base",
+    "github>dev-hato/renovate-config"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
`dev-hato/renovate-config` を最後に適用する形にすることで、 `dev-hato/renovate-config` の設定が全て適用されるようにします。