### PR TITLE
config:baseを明示的に適用しないようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "github>dev-hato/renovate-config",
-    "config:base"
+    "github>dev-hato/renovate-config"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
`config:base` は `dev-hato/renovate-config` に含まれており、 `dev-hato/renovate-config` の上に `config:base` を適用すると `prConcurrentLimit` の設定が `config:base` のものになってしまうので、明示的に指定しないようにします。