### PR TITLE
DynamoDBに投げるクエリのWHERE IN句内に一度に入れる要素の数を制限する

### DIFF
--- a/src/common/dynamodb.ts
+++ b/src/common/dynamodb.ts
@@ -25,6 +25,7 @@ if (process.env.NODE_ENV === 'development' &&
   }
 }
 
+export const maxWhereInNum=50
 export const dynamoDBClient = new DynamoDBClient(dynamoDBClientConfig)
 
 export async function runQuery (partiQLQuery: string, parameters?: AttributeValue[]): Promise<Array<{

--- a/src/common/dynamodb.ts
+++ b/src/common/dynamodb.ts
@@ -25,7 +25,7 @@ if (process.env.NODE_ENV === 'development' &&
   }
 }
 
-export const maxWhereInNum=50
+export const maxWhereInNum = 50
 export const dynamoDBClient = new DynamoDBClient(dynamoDBClientConfig)
 
 export async function runQuery (partiQLQuery: string, parameters?: AttributeValue[]): Promise<Array<{

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -260,7 +260,7 @@ export async function handler (): Promise<void> {
             }
           }
 
-          let tweetDataResults:Array<{
+          let tweetDataResults: Array<{
             [key: string]: AttributeValue
           }> = []
 
@@ -459,7 +459,7 @@ export async function handler (): Promise<void> {
       }
 
       const videoIdList = Array.from(videoIdsPerChannels[channelId])
-      let postedVideos:Array<{
+      let postedVideos: Array<{
         [key: string]: AttributeValue
       }> = []
 

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -5,7 +5,7 @@ import { TweetV2, TweetV2UserTimelineParams, ApiResponseError } from 'twitter-ap
 import { AttributeValue } from '@aws-sdk/client-dynamodb'
 import { ChatPostMessageArguments } from '@slack/web-api'
 import { google, youtube_v3 } from 'googleapis' // eslint-disable-line camelcase
-import {maxWhereInNum, runQuery} from '../common/dynamodb'
+import { maxWhereInNum, runQuery } from '../common/dynamodb'
 import { slackApp } from '../common/slack'
 import { twitterApiReadOnly } from '../common/twitter'
 
@@ -264,15 +264,14 @@ export async function handler (): Promise<void> {
             [key: string]: AttributeValue
           }> = []
 
-          for (let i=0; i<Math.ceil(tweetIds.length / maxWhereInNum); i++) {
-            const tweetIdsPart=tweetIds.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
-            tweetDataResults=tweetDataResults.concat(await runQuery(
-                'SELECT tweet_id, video_id, updated_time FROM youtube_streaming_watcher_tweet_videos ' +
+          for (let i = 0; i < Math.ceil(tweetIds.length / maxWhereInNum); i++) {
+            const tweetIdsPart = tweetIds.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
+            tweetDataResults = tweetDataResults.concat(await runQuery(
+              'SELECT tweet_id, video_id, updated_time FROM youtube_streaming_watcher_tweet_videos ' +
                 'WHERE tweet_id IN (' + tweetIdsPart.map(() => '?').join(', ') + ')',
-                tweetIdsPart
+              tweetIdsPart
             ))
           }
-
 
           for (const tweetDataResult of tweetDataResults) {
             if (tweetDataResult.tweet_id.S !== undefined &&
@@ -462,17 +461,17 @@ export async function handler (): Promise<void> {
       const videoIdList = Array.from(videoIdsPerChannels[channelId])
       let postedVideos:Array<{
         [key: string]: AttributeValue
-      }> =[]
+      }> = []
 
       // 登録済み配信取得
-      for (let i=0; i<Math.ceil(videoIdList.length / maxWhereInNum); i++) {
-        const videoIdPartList=videoIdList.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
-        postedVideos=postedVideos.concat(await runQuery(
-            'SELECT video_id, start_time, updated_time, notify_mode, privacy_status, is_live_streaming FROM youtube_streaming_watcher_notified_videos ' +
+      for (let i = 0; i < Math.ceil(videoIdList.length / maxWhereInNum); i++) {
+        const videoIdPartList = videoIdList.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
+        postedVideos = postedVideos.concat(await runQuery(
+          'SELECT video_id, start_time, updated_time, notify_mode, privacy_status, is_live_streaming FROM youtube_streaming_watcher_notified_videos ' +
             'WHERE channel_id=? AND video_id IN (' + videoIdPartList.map(() => '?').join(', ') + ')',
-            [{ S: channelId }].concat(videoIdPartList.map(v => {
-              return { S: v }
-            }))))
+          [{ S: channelId }].concat(videoIdPartList.map(v => {
+            return { S: v }
+          }))))
       }
 
       for (const item of postedVideos) {

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -264,7 +264,7 @@ export async function handler (): Promise<void> {
             [key: string]: AttributeValue
           }> = []
 
-          for (let i=0; i<Math.ceil(tweetIds.length / maxWhereInNum); i++)　{
+          for (let i=0; i<Math.ceil(tweetIds.length / maxWhereInNum); i++) {
             const tweetIdsPart=tweetIds.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
             tweetDataResults=tweetDataResults.concat(await runQuery(
                 'SELECT tweet_id, video_id, updated_time FROM youtube_streaming_watcher_tweet_videos ' +
@@ -465,7 +465,7 @@ export async function handler (): Promise<void> {
       }> =[]
 
       // 登録済み配信取得
-      for (let i=0; i<Math.ceil(videoIdList.length / maxWhereInNum); i++)　{
+      for (let i=0; i<Math.ceil(videoIdList.length / maxWhereInNum); i++) {
         const videoIdPartList=videoIdList.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
         postedVideos=postedVideos.concat(await runQuery(
             'SELECT video_id, start_time, updated_time, notify_mode, privacy_status, is_live_streaming FROM youtube_streaming_watcher_notified_videos ' +

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -5,7 +5,7 @@ import { TweetV2, TweetV2UserTimelineParams, ApiResponseError } from 'twitter-ap
 import { AttributeValue } from '@aws-sdk/client-dynamodb'
 import { ChatPostMessageArguments } from '@slack/web-api'
 import { google, youtube_v3 } from 'googleapis' // eslint-disable-line camelcase
-import { runQuery } from '../common/dynamodb'
+import {maxWhereInNum, runQuery} from '../common/dynamodb'
 import { slackApp } from '../common/slack'
 import { twitterApiReadOnly } from '../common/twitter'
 
@@ -260,11 +260,19 @@ export async function handler (): Promise<void> {
             }
           }
 
-          const tweetDataResults = await runQuery(
-            'SELECT tweet_id, video_id, updated_time FROM youtube_streaming_watcher_tweet_videos ' +
-            'WHERE tweet_id IN (' + tweetIds.map(() => '?').join(', ') + ')',
-            tweetIds
-          )
+          let tweetDataResults:Array<{
+            [key: string]: AttributeValue
+          }> = []
+
+          for (let i=0; i<Math.ceil(tweetIds.length / maxWhereInNum); i++)　{
+            const tweetIdsPart=tweetIds.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
+            tweetDataResults=tweetDataResults.concat(await runQuery(
+                'SELECT tweet_id, video_id, updated_time FROM youtube_streaming_watcher_tweet_videos ' +
+                'WHERE tweet_id IN (' + tweetIdsPart.map(() => '?').join(', ') + ')',
+                tweetIdsPart
+            ))
+          }
+
 
           for (const tweetDataResult of tweetDataResults) {
             if (tweetDataResult.tweet_id.S !== undefined &&
@@ -452,15 +460,20 @@ export async function handler (): Promise<void> {
       }
 
       const videoIdList = Array.from(videoIdsPerChannels[channelId])
+      let postedVideos:Array<{
+        [key: string]: AttributeValue
+      }> =[]
 
       // 登録済み配信取得
-      const postedVideos = await runQuery(
-        'SELECT video_id, start_time, updated_time, notify_mode, privacy_status, is_live_streaming FROM youtube_streaming_watcher_notified_videos ' +
-                'WHERE channel_id=? AND video_id IN (' + videoIdList.map(() => '?').join(', ') + ')',
-        [{ S: channelId }].concat(videoIdList.map(v => {
-          return { S: v }
-        }))
-      )
+      for (let i=0; i<Math.ceil(videoIdList.length / maxWhereInNum); i++)　{
+        const videoIdPartList=videoIdList.slice(i * maxWhereInNum, (i + 1) * maxWhereInNum)
+        postedVideos=postedVideos.concat(await runQuery(
+            'SELECT video_id, start_time, updated_time, notify_mode, privacy_status, is_live_streaming FROM youtube_streaming_watcher_notified_videos ' +
+            'WHERE channel_id=? AND video_id IN (' + videoIdPartList.map(() => '?').join(', ') + ')',
+            [{ S: channelId }].concat(videoIdPartList.map(v => {
+              return { S: v }
+            }))))
+      }
 
       for (const item of postedVideos) {
         const videoId = item.video_id.S


### PR DESCRIPTION
```
ERROR	ValidationException: Too many decomposed read operations for a given query.
    at aUo (/var/task/index.js:103:6774896)
    at I_o (/var/task/index.js:109:89273)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /var/task/index.js:103:6761457
    at async /var/task/index.js:120:4094
    at async nye.retry (/var/task/index.js:109:298280)
    at async /var/task/index.js:109:279554
    at async Nm (/var/task/index.js:259:32856)
    at async Runtime.K3r [as handler] (/var/task/index.js:269:2206) {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: '1TEIDH24NBKGNMMT0QAN5RTENJVV4KQNSO5AEMVJF66Q9ASUAAJG',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  __type: 'com.amazon.coral.validate#ValidationException'
}
```

https://stackoverflow.com/questions/72463744/dynamodbexception-too-many-decomposed-read-operations-for-a-given-query
>For WHERE IN queries on a secondary index attribute, there is a limit of 50 items.

DynamoDBに投げるクエリのWHERE IN句内に一度に入れる要素を50個以内に制限します。