### PR TITLE
tweet_videosのread capacityを4にする

### DIFF
--- a/lib/props/dynamodb-table-props.ts
+++ b/lib/props/dynamodb-table-props.ts
@@ -44,7 +44,7 @@ export const dynamoDBTableProps: dynamodb.TableProps[] = [
     tableName: 'youtube_streaming_watcher_tweet_videos',
     partitionKey: { name: 'tweet_id', type: dynamodb.AttributeType.STRING },
     sortKey: { name: 'video_id', type: dynamodb.AttributeType.STRING },
-    readCapacity: 2,
+    readCapacity: 4,
     writeCapacity: 1
   }
 ]


### PR DESCRIPTION
```
ERROR	ProvisionedThroughputExceededException: The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
    at UP (/var/task/index.js:109:117970)
    at x_o (/var/task/index.js:109:88903)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /var/task/index.js:103:6761457
    at async /var/task/index.js:120:4094
    at async iye.retry (/var/task/index.js:109:298280)
    at async /var/task/index.js:109:279554
    at async Nm (/var/task/index.js:259:32862)
    at async Runtime.W3r [as handler] (/var/task/index.js:269:2301) {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: 'K8V61CHQ9143AVE2CUEHAT7V9RVV4KQNSO5AEMVJF66Q9ASUAAJG',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 3,
    totalRetryDelay: 953
  },
  __type: 'com.amazonaws.dynamodb.v20120810#ProvisionedThroughputExceededException'
}
```

`youtube_streaming_watcher_tweet_videos` のread capacityを4にします。