### PR TITLE
cdk系のCIの実行対象のファイルを指定する

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -5,6 +5,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/cdk-deploy.yml
+      - bin/cdk.ts
+      - lib/**
+      - src/**
+      - .node-version
+      - cdk.json
+      - package*.json
+      - tsconfig.json
+      - .npm*
 
 jobs:
   cdk-deploy:

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -3,6 +3,16 @@ name: cdk-diff
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/cdk-diff.yml
+      - bin/cdk.ts
+      - lib/**
+      - src/**
+      - .node-version
+      - cdk.json
+      - package*.json
+      - tsconfig.json
+      - .npm*
 
 jobs:
   cdk-diff:


### PR DESCRIPTION
cdk系のCIによるものと思われるS3へのアクセスによってS3の無料枠を超えているので、実行対象のファイルを指定してアクセスを減らします。