### PR TITLE
cdkのCIをスキップする場合でもstatus checkが通るようにする

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -62,7 +62,7 @@ jobs:
       - check-cdk-diff
       - cdk-deploy
     steps:
-      - if: needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success'
+      - if: ${{ needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success' }}
         run: exit 0
-      - if: !(needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success')
+      - if: ${{ !(needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success') }}
         run: exit 1

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -5,22 +5,35 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/cdk-deploy.yml
-      - bin/cdk.ts
-      - lib/**
-      - src/**
-      - .node-version
-      - cdk.json
-      - package*.json
-      - tsconfig.json
-      - .npm*
 
 jobs:
+  check-cdk-diff:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy-files: ${{ steps.changes.outputs.deploy-files }}
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: dorny/paths-filter@v2.10.2
+        id: changes
+        with:
+          filters: |
+            deploy-files:
+              - .github/workflows/cdk-deploy.yml
+              - bin/cdk.ts
+              - lib/**
+              - src/**
+              - .node-version
+              - cdk.json
+              - package*.json
+              - tsconfig.json
+              - .npm*
+
   cdk-deploy:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    needs: check-cdk-diff
+    if: needs.check-cdk-diff.outputs.deploy-files == 'true'
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"
@@ -41,3 +54,15 @@ jobs:
           npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       - run: npx cdk deploy --require-approval never
+
+  cdk-diff-complete:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - check-cdk-diff
+      - cdk-deploy
+    steps:
+      - if: needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success'
+        run: exit 0
+      - if: !(needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success')
+        run: exit 1

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -3,25 +3,38 @@ name: cdk-diff
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/cdk-deploy.yml
-      - .github/workflows/cdk-diff.yml
-      - bin/cdk.ts
-      - lib/**
-      - src/**
-      - .node-version
-      - cdk.json
-      - package*.json
-      - tsconfig.json
-      - .npm*
 
 jobs:
+  check-cdk-diff:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy-files: ${{ steps.changes.outputs.deploy-files }}
+    if: github.repository == github.event.pull_request.head.repo.full_name && github.event.action != 'closed'
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: dorny/paths-filter@v2.10.2
+        id: changes
+        with:
+          filters: |
+            deploy-files:
+              - .github/workflows/cdk-deploy.yml
+              - .github/workflows/cdk-diff.yml
+              - bin/cdk.ts
+              - lib/**
+              - src/**
+              - .node-version
+              - cdk.json
+              - package*.json
+              - tsconfig.json
+              - .npm*
+
   cdk-diff:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: write
-    if: github.repository == github.event.pull_request.head.repo.full_name
+    needs: check-cdk-diff
+    if: needs.check-cdk-diff.outputs.deploy-files == 'true'
     steps:
       - run: |
           ROLE="arn:aws:iam::${{ secrets.AWS_ACCOUNT }}"
@@ -73,4 +86,16 @@ jobs:
               body,
             })
       - if: steps.diff.outcome == 'failure'
+        run: exit 1
+
+  cdk-diff-complete:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - check-cdk-diff
+      - cdk-diff
+    steps:
+      - if: ${{ github.repository != github.event.pull_request.head.repo.full_name || needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-diff.result == 'success' }}
+        run: exit 0
+      - if: ${{ !(github.repository != github.event.pull_request.head.repo.full_name || needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-diff.result == 'success') }}
         run: exit 1


### PR DESCRIPTION
cdkに関する差分がないせいで `cdk diff` が通らないケースがあるので ( https://github.com/dev-hato/youtube_streaming_watcher/pull/1100 )、そのような場合でも通るようにします。