### PR TITLE
Dockerでのnpm ci実行前にnpmのキャッシュをクリアする

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 engine-strict=true
-fetch-retry-mintimeout=20000
-fetch-retry-maxtimeout=120000
+registry=http://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-registry=http://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
+fetch-retry-mintimeout=20000
 fetch-retry-maxtimeout=120000

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+fetch-retry-maxtimeout=120000

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ COPY .node-version .
 COPY .npmignore .
 COPY .npmrc .
 COPY package*.json .
-RUN npm ci \
+RUN npm cache clear \
+    && npm ci \
     && rm -rf /home/node/.npm
 COPY tsconfig.json .
 COPY lib/props/ lib/props/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY .node-version .
 COPY .npmignore .
 COPY .npmrc .
 COPY package*.json .
-RUN npm cache clear \
+RUN npm cache clear --force \
     && npm ci \
     && rm -rf /home/node/.npm
 COPY tsconfig.json .


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/actions/runs/3309287287/jobs/5462319640

```
#64 1083.5 npm ERR! code ERR_SOCKET_TIMEOUT
#64 1083.7 npm ERR! network Socket timeout
#64 1083.7 npm ERR! network This is a problem related to network connectivity.
#64 1083.7 npm ERR! network In most cases you are behind a proxy or have bad network settings.
#64 1083.7 npm ERR! network 
#64 1083.7 npm ERR! network If you are behind a proxy, please make sure that the
#64 1083.7 npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
```

上記エラーを解消するため、Dockerでのnpm ci実行前にnpmのキャッシュをクリアします。