### PR TITLE
Revert "Dockerでのnpm ci実行前にnpmのキャッシュをクリアする"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ COPY .node-version .
 COPY .npmignore .
 COPY .npmrc .
 COPY package*.json .
-RUN npm cache clear --force \
-    && npm ci \
+RUN npm ci \
     && rm -rf /home/node/.npm
 COPY tsconfig.json .
 COPY lib/props/ lib/props/


### PR DESCRIPTION
エラーが解消されなかったので dev-hato/youtube_streaming_watcher#1352 をRevertします。