### PR TITLE
連続pushした際に古いコミットのCIをキャンセルする

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -62,7 +62,3 @@ jobs:
         run: exit 0
       - if: ${{ !(needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success') }}
         run: exit 1
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -62,3 +62,7 @@ jobs:
         run: exit 0
       - if: ${{ !(needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-deploy.result == 'success') }}
         run: exit 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -79,3 +79,7 @@ jobs:
         run: exit 0
       - if: ${{ !(github.repository != github.event.pull_request.head.repo.full_name || needs.check-cdk-diff.outputs.deploy-files == 'false' || needs.cdk-diff.result == 'success') }}
         run: exit 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -77,3 +77,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -211,3 +211,7 @@ jobs:
         run: exit 0
       - if: ${{ !(needs.update-version.result == 'success' && needs.dockle.result == 'success') }}
         run: exit 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -28,3 +28,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           repo-name: dev-hato/youtube_streaming_watcher
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -37,3 +37,7 @@ jobs:
           branch-name-prefix: fix-format
           pr-title-prefix: formatを直してあげたよ！
           repo-name: ${{ github.event.pull_request.head.repo.full_name }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -19,3 +19,7 @@ jobs:
           cache: npm
       - run: bash "${GITHUB_WORKSPACE}/scripts/npm_ci.sh"
       - run: npx renovate-config-validator
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -82,3 +82,7 @@ jobs:
       ################################
       - name: Lint dotenv
         uses: dotenv-linter/action-dotenv-linter@v2.16.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -34,3 +34,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           repo-name: ${{ github.event.pull_request.head.repo.full_name }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -68,3 +68,7 @@ jobs:
           branch-name-prefix: update-packages
           pr-title-prefix: expressをアップデートしてあげたよ！
           repo-name: ${{ github.event.pull_request.head.repo.full_name }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
https://zenn.dev/katzumi/articles/using-concurrency-at-github-actions

PRをトリガーとするCIについて、連続pushした際に古いコミットのCIをキャンセルするようにします。