### PR TITLE
OIDCプロバイダーにthumbprintsを明示的に指定する

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -125,7 +125,8 @@ export class CdkStack extends Stack {
     const oidcAud = 'sts.amazonaws.com'
     const provider = new iam.OpenIdConnectProvider(this, 'OIDCProvider-github', {
       url: 'https://token.actions.githubusercontent.com',
-      clientIds: [oidcAud]
+      clientIds: [oidcAud],
+      thumbprints: ['6938FD4D98BAB03FAADB97B34396831E3780AEA1'],
     })
 
     const qualifier: string = this.node.tryGetContext(BOOTSTRAP_QUALIFIER_CONTEXT) ?? DefaultStackSynthesizer.DEFAULT_QUALIFIER

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -126,7 +126,7 @@ export class CdkStack extends Stack {
     const provider = new iam.OpenIdConnectProvider(this, 'OIDCProvider-github', {
       url: 'https://token.actions.githubusercontent.com',
       clientIds: [oidcAud],
-      thumbprints: ['6938FD4D98BAB03FAADB97B34396831E3780AEA1'],
+      thumbprints: ['6938FD4D98BAB03FAADB97B34396831E3780AEA1']
     })
 
     const qualifier: string = this.node.tryGetContext(BOOTSTRAP_QUALIFIER_CONTEXT) ?? DefaultStackSynthesizer.DEFAULT_QUALIFIER


### PR DESCRIPTION
https://github.com/aws/aws-cdk/issues/8607

GitHub ActionsからOIDC経由でAWSにアクセスできなくなっているので、OIDCプロバイダーにthumbprintsを明示的に指定します。
CIから `cdk diff` や `cdk deploy` が実行できないので、approveをもらったら手元で `cdk deploy` を実行し、CIを再実行してマージする予定です。

[手元でのcdk diff]

```
$ cdk diff
Bundling asset Stack-youtube-streaming-watcher/Function-notify/Code/Stage...

  cdk.out/bundling-temp-cb7f3c84307603a7f3b18c54aa1a86cae1f73919b64b1f321f917d2bd51c43a6/index.js      10.9mb ⚠️
  cdk.out/bundling-temp-cb7f3c84307603a7f3b18c54aa1a86cae1f73919b64b1f321f917d2bd51c43a6/index.js.map  37.1mb

⚡ Done in 907ms
Bundling asset Stack-youtube-streaming-watcher/Function-reply/Code/Stage...

  cdk.out/bundling-temp-77d926a2a53e0843ad3a0aadbf658de93a9b4aa8b5c8b862ec401c9d0456cfb5/index.js      2.9mb ⚠️
  cdk.out/bundling-temp-77d926a2a53e0843ad3a0aadbf658de93a9b4aa8b5c8b862ec401c9d0456cfb5/index.js.map  7.4mb

⚡ Done in 175ms
Stack Stack-youtube-streaming-watcher
Resources
[~] Custom::AWSCDKOpenIdConnectProvider OIDCProvider-github/Resource OIDCProvidergithubA71ED85C 
 └─ [+] ThumbprintList
     └─ ["6938FD4D98BAB03FAADB97B34396831E3780AEA1"]


NOTICES

8607    aws-iam: IAM OIDC provider configures the wrong certificate thumbprint

        Overview: Your application is using the iam.OpenIDConnectProvider
                  resource, which currently configures the thumbprint of the
                  leaf certificate instead of the root. Since leaf
                  certificates are rotated more frequently, you are in danger
                  of application errors next time those certificates get
                  rotated. See the attached issue for mitigation steps and
                  apply them as soon as possible.

        Affected versions: aws-cdk-lib.aws_iam.OpenIdConnectProvider: ^2.0.0, @aws-cdk/aws-iam.OpenIdConnectProvider: ^1.0.0

        More information at: https://github.com/aws/aws-cdk/issues/8607


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 8607".
```