### PR TITLE
Revert "OIDCプロバイダーにthumbprintsを明示的に指定する"

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -125,8 +125,7 @@ export class CdkStack extends Stack {
     const oidcAud = 'sts.amazonaws.com'
     const provider = new iam.OpenIdConnectProvider(this, 'OIDCProvider-github', {
       url: 'https://token.actions.githubusercontent.com',
-      clientIds: [oidcAud],
-      thumbprints: ['6938FD4D98BAB03FAADB97B34396831E3780AEA1']
+      clientIds: [oidcAud]
     })
 
     const qualifier: string = this.node.tryGetContext(BOOTSTRAP_QUALIFIER_CONTEXT) ?? DefaultStackSynthesizer.DEFAULT_QUALIFIER


### PR DESCRIPTION
https://github.com/dev-hato/youtube_streaming_watcher/pull/1489 で `aws-cdk` をアップデートしたため、 dev-hato/youtube_streaming_watcher#1482 をRevertします。