### PR TITLE
英語版のAWSのページからLambdaランタイム情報を取得する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         versions:
-          - '>16'
+          - '>18'
       - dependency-name: express
         versions:
           - '>4.17'

--- a/.github/workflows/update-major-node.yml
+++ b/.github/workflows/update-major-node.yml
@@ -4,6 +4,15 @@ name: update-major-node
 on:
   schedule:
     - cron: '0 21 * * *' # 06:00 JST
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+    paths:
+      - .github/workflows/update-major-node.yml
+      - scripts/update_major_node/update_major_node/*
 
 jobs:
   # AWS Lambdaのランタイムのページをスクレイピングし、そこに記述されているNode.jsランタイムのバージョンがアップデートされていたらDockerイメージをアップデートする

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "matchPackageNames": [
         "@types/node"
       ],
-      "allowedVersions": "<=16"
+      "allowedVersions": "<=18"
     },
     {
       "matchPackageNames": [

--- a/scripts/update_major_node/update_major_node/get_latest_lambda_support_version.js
+++ b/scripts/update_major_node/update_major_node/get_latest_lambda_support_version.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio')
 const { Text } = require('domhandler')
 
 module.exports = async () => {
-  const response = await axios.get('https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html')
+  const response = await axios.get('https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html')
   const $ = cheerio.load(response.data)
   const versions = []
 


### PR DESCRIPTION
Lambdaのランタイム情報は英語版と日本語版で反映のタイムラグがあるようなので、より最新と考えられる英語版から情報を取得するようにします。
また、動作確認しやすいようにCIの関連ファイルに差分がある時に動作するようにします。