### PR TITLE
cache掃除の閾値を8GBにする

### DIFF
--- a/scripts/clean_cache/clean_cache/clean-cache.js
+++ b/scripts/clean_cache/clean_cache/clean-cache.js
@@ -7,7 +7,7 @@ module.exports = async ({ github, context }) => {
     console.log('call actions.getActionsCacheUsage', actionsGetActionsCacheUsageParams)
     const actionsCacheUsage = await github.rest.actions.getActionsCacheUsage(actionsGetActionsCacheUsageParams)
 
-    if (actionsCacheUsage.data.active_caches_size_in_bytes <= 9 * 1024 * 1024 * 1024) {
+    if (actionsCacheUsage.data.active_caches_size_in_bytes <= 8 * 1024 * 1024 * 1024) {
       return
     }
 


### PR DESCRIPTION
cacheが8.4GBあると多すぎると判定されるようなので、cache掃除の閾値を8GBにします。