### PR TITLE
コスト異常検出のStackをデプロイしない

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 import { App } from 'aws-cdk-lib'
 import { DefaultCdkStack } from '../lib/default/cdk-stack'
-import { CEAnomalyCdkStack } from '../lib/cd-anomaly/cdk-stack'
 
 const app = new App()
 new DefaultCdkStack(app, 'Stack-youtube-streaming-watcher') // eslint-disable-line no-new
-new CEAnomalyCdkStack(app, 'Stack-youtube-streaming-watcher-us-east-1', { env: { region: 'us-east-1' } }) // eslint-disable-line no-new


### PR DESCRIPTION
デプロイ用のIAMユーザーにコスト異常検出のStackをデプロイする権限を付与する必要があるため、一旦コスト異常検出のStackをデプロイしないようにします。
権限付与に成功したら本PRをRevert予定です。